### PR TITLE
Add Albireo V2 OAuth2 authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ Watch bangumi on Apple devices
 let bgmAppID = "<Your AppID from bgm.tv>"
 let bgmAppSecret = "<Your AppSecret from bgm.tv>"
 let testURL = "<Your Albreo server URL, optional>"
+let albireoV2ClientID = "<Your Albireo V2 OAuth2 Client ID, optional>"
+let albireoV2DefaultAuthorizationServerURL = "<Your Albireo V2 authorization server URL, optional>"
+let albireoV2DefaultAPIServerURL = "<Your Albireo V2 API server URL, optional>"
+let albireoV2RedirectHost = "<Your OAuth2 redirect host for moetv://, optional>"
 ```
+These constants must exist even if you leave the optional values empty. `albireoV2ClientID` and `albireoV2RedirectHost` can also be entered from the OAuth2 login screen at runtime.
 4. Open Xcode, build & run.
 
 ## URL Schemes

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -3,7 +3,15 @@
 echo "Stage: PRE-Xcode Build is activated .... "
 
 # Write a Swift File containing all the environment variables and secrets.
-printf "let bgmAppID = \"%s\"\nlet bgmAppSecret = \"%s\" " "$bgmAppID" "$bgmAppSecret" >> ../moe.TV/DONOTUPLOAD.swift
+{
+	printf "let bgmAppID = \"%s\"\n" "$bgmAppID"
+	printf "let bgmAppSecret = \"%s\"\n" "$bgmAppSecret"
+	printf "let testURL = \"%s\"\n" "$testURL"
+	printf "let albireoV2ClientID = \"%s\"\n" "$albireoV2ClientID"
+	printf "let albireoV2DefaultAuthorizationServerURL = \"%s\"\n" "$albireoV2DefaultAuthorizationServerURL"
+	printf "let albireoV2DefaultAPIServerURL = \"%s\"\n" "$albireoV2DefaultAPIServerURL"
+	printf "let albireoV2RedirectHost = \"%s\"\n" "$albireoV2RedirectHost"
+} >> ../moe.TV/DONOTUPLOAD.swift
 
 echo "Wrote swift file."
 

--- a/moe.TV.xcodeproj/project.pbxproj
+++ b/moe.TV.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		477801792FA34C77004757F4 /* TVSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477801782FA34C71004757F4 /* TVSidebar.swift */; };
 		4779043B2F2B857900EF74D5 /* PlayerViewControllerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779043A2F2B854500EF74D5 /* PlayerViewControllerHost.swift */; };
 		4779043F2F2B91F400EF74D5 /* NowPlayingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779043E2F2B91D000EF74D5 /* NowPlayingManager.swift */; };
+		47AA00022F30000000123456 /* AlbireoV2ServerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AA00012F30000000123456 /* AlbireoV2ServerHandler.swift */; };
+		47AA00122F30010000123456 /* AlbireoV2Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AA00112F30010000123456 /* AlbireoV2Model.swift */; };
 		47CC30782A371784001D3F8C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC30772A371784001D3F8C /* LoginViewController.swift */; };
 		47CC307B2A38952A001D3F8C /* BangumiCellUnreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC307A2A38952A001D3F8C /* BangumiCellUnreadView.swift */; };
 		47CC307D2A389AE7001D3F8C /* BangumiDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC307C2A389AE7001D3F8C /* BangumiDetailModel.swift */; };
@@ -115,6 +117,8 @@
 		477801782FA34C71004757F4 /* TVSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVSidebar.swift; sourceTree = "<group>"; };
 		4779043A2F2B854500EF74D5 /* PlayerViewControllerHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewControllerHost.swift; sourceTree = "<group>"; };
 		4779043E2F2B91D000EF74D5 /* NowPlayingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingManager.swift; sourceTree = "<group>"; };
+		47AA00012F30000000123456 /* AlbireoV2ServerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbireoV2ServerHandler.swift; sourceTree = "<group>"; };
+		47AA00112F30010000123456 /* AlbireoV2Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbireoV2Model.swift; sourceTree = "<group>"; };
 		47CC30772A371784001D3F8C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		47CC307A2A38952A001D3F8C /* BangumiCellUnreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BangumiCellUnreadView.swift; sourceTree = "<group>"; };
 		47CC307C2A389AE7001D3F8C /* BangumiDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BangumiDetailModel.swift; sourceTree = "<group>"; };
@@ -228,6 +232,14 @@
 			path = Albireo;
 			sourceTree = "<group>";
 		};
+		47AA00132F30010000123456 /* AlbireoV2 */ = {
+			isa = PBXGroup;
+			children = (
+				47AA00112F30010000123456 /* AlbireoV2Model.swift */,
+			);
+			path = AlbireoV2;
+			sourceTree = "<group>";
+		};
 		47CC30762A37156D001D3F8C /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -258,6 +270,7 @@
 			isa = PBXGroup;
 			children = (
 				477904412F2B9C7C00EF74D5 /* Albireo */,
+				47AA00132F30010000123456 /* AlbireoV2 */,
 				477904402F2B9C5000EF74D5 /* BGMTV */,
 			);
 			path = APIModel;
@@ -273,6 +286,7 @@
 				8627A9362A343DBC00A5FCAC /* SettingsHandler.swift */,
 				866E4EB12CE3AC270077D38D /* PlaybackHistoryHandler.swift */,
 				8627A9312A343D6500A5FCAC /* AlbireoServerHandler.swift */,
+				47AA00012F30000000123456 /* AlbireoV2ServerHandler.swift */,
 				86112E852A3C73F60034AD97 /* BGMTVServerHandler.swift */,
 				8658C6902A50839100357761 /* OpenURL.swift */,
 				86B06C2F2C156B2400169F55 /* ViewUtils.swift */,
@@ -558,6 +572,8 @@
 				86A968FA2A7FCD4900E9BD59 /* DownloadManager.swift in Sources */,
 				86112E862A3C73F60034AD97 /* BGMTVServerHandler.swift in Sources */,
 				8627A9322A343D6500A5FCAC /* AlbireoServerHandler.swift in Sources */,
+				47AA00022F30000000123456 /* AlbireoV2ServerHandler.swift in Sources */,
+				47AA00122F30010000123456 /* AlbireoV2Model.swift in Sources */,
 				8622C61C2A9261B70099DC78 /* ProgressAlertView.swift in Sources */,
 				47CC307D2A389AE7001D3F8C /* BangumiDetailModel.swift in Sources */,
 				860412132DB4C943006E4FF0 /* BGMTVUserSubjectCollectionModel.swift in Sources */,
@@ -836,7 +852,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = moe.TV/moe_TV.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202506042051;
+				CURRENT_PROJECT_VERSION = 202607151712;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "moe.TV/Support\\ Files/Preview\\ Content Assets.xcassets";
 				ENABLE_APP_SANDBOX = YES;
@@ -897,7 +913,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = moe.TV/moe_TV.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202506042051;
+				CURRENT_PROJECT_VERSION = 202607151712;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "moe.TV/Support\\ Files/Preview\\ Content Assets.xcassets";
 				ENABLE_APP_SANDBOX = YES;

--- a/moe.TV/Controller/BangumiDetailViewController.swift
+++ b/moe.TV/Controller/BangumiDetailViewController.swift
@@ -14,6 +14,8 @@ struct NewEPItem:Decodable {
 }
 
 class BangumiDetailViewController : ObservableObject {
+	private let settingsHandler = SettingsHandler()
+
     @Published var presentVideoView = false
     @Published var presentContinuePlayAlert = false
     @Published var presentSourceSelectAlert = false
@@ -61,14 +63,15 @@ class BangumiDetailViewController : ObservableObject {
     //2 check last position
     func checkLastWatchPosition(ep:EpisodeDetailModel){
         if let watchProgress = ep.watch_progress{
-            if watchProgress.percentage != 0 ||
-                watchProgress.percentage != 1{
+			let percentage = watchProgress.percentage ?? 0
+			let lastWatchPosition = watchProgress.last_watch_position ?? 0
+			if lastWatchPosition > 0 && percentage > 0 && percentage < 0.95 {
                 print("can seek")
                 DispatchQueue.main.async {
                     self.presentContinuePlayAlert = true
                 }
             }else{
-                print("percentage 0 or 1")
+                print("no resumable progress")
                 self.checkVideoSource(ep:ep, seekTime: 0)
             }
         }else{
@@ -138,6 +141,80 @@ class BangumiDetailViewController : ObservableObject {
 		self.newEPList = []
 		self.isFinished = false
         self.favStatusLoaded = false
+		settingsHandler.registerSettings()
+		if settingsHandler.getAlbireoAuthMode() == .albireoV2OAuth {
+			getAlbireoV2BangumiDetail(id: id) { isSuccessed, data in
+				if !isSuccessed {
+					DispatchQueue.main.async {
+						self.isFinished = true
+						self.favStatusLoaded = true
+					}
+					print("Albireo V2 bangumi detail failed: \(data)")
+					completion(false)
+					return
+				}
+
+				guard let responseData = data as? Data else {
+					DispatchQueue.main.async {
+						self.isFinished = true
+						self.favStatusLoaded = true
+					}
+					print("Albireo V2 bangumi detail response is not Data: \(data)")
+					completion(false)
+					return
+				}
+
+				do {
+					let bgmItem = try decodeAlbireoV2BangumiDetail(from: responseData)
+					let episodes = bgmItem.episodes ?? []
+					DispatchQueue.main.async {
+						self.detailItem = bgmItem
+						self.albireo_favorite_status = bgmItem.favorite_status ?? 0
+					}
+
+					if isBGMTVlogined() {
+						self.getBGMTVFAVStatus(item: bgmItem) { isSuccessed, result in
+							DispatchQueue.main.async {
+								self.bgmtv_favorite_status = isSuccessed ? result : 0
+								self.favStatusLoaded = true
+							}
+						}
+
+						if let bgmID = bgmItem.bgm_id {
+							self.getBGMTVEPList(
+								bgmID: bgmID,
+								epList: episodes
+							)
+						} else {
+							print("bgmId/bgm_id is empty")
+							DispatchQueue.main.async {
+								self.showOnlyAlbireoEPs(eps: episodes)
+								self.favStatusLoaded = true
+							}
+						}
+						completion(true)
+						return
+					}
+
+					DispatchQueue.main.async {
+						self.bgmtv_favorite_status = 0
+						self.favStatusLoaded = true
+						self.showOnlyAlbireoEPs(eps: episodes)
+						completion(true)
+					}
+				} catch {
+					DispatchQueue.main.async {
+						self.isFinished = true
+						self.favStatusLoaded = true
+					}
+					let responseText = String(data: responseData, encoding: .utf8) ?? ""
+					print("Albireo V2 bangumi detail decode failed: \(error.localizedDescription), response: \(responseText)")
+					completion(false)
+				}
+			}
+			return
+		}
+
         getAlbireoBangumiDetail(id: id) { isSuccessed, data in
             if !isSuccessed{
                 self.isFinished = true
@@ -263,14 +340,19 @@ class BangumiDetailViewController : ObservableObject {
 
 	func showOnlyAlbireoEPs(eps:[BGMEpisode]){
 		print("showOnlyAlbireoEPs")
-		self.newEPList.removeAll()
-		DispatchQueue.main.async {
+		let update = {
+			self.newEPList.removeAll()
 			self.newEPList = self.combineEPList(
 				eps: eps,
 				bgmEPs: []
 			)
 			self.isFinished = true
             print("Finished: showOnlyAlbireoEPs")
+		}
+		if Thread.isMainThread {
+			update()
+		} else {
+			DispatchQueue.main.async(execute: update)
 		}
 	}
 

--- a/moe.TV/Controller/BangumiListViewController.swift
+++ b/moe.TV/Controller/BangumiListViewController.swift
@@ -11,10 +11,16 @@ import Foundation
 class BangumiListViewController: ObservableObject{
     @Published var bgmList = [BangumiItemModel]()
     @Published var isLoading = false
+	@Published var isLoadingNextPage = false
     @Published var searchText = ""
     @Published var showLogoutAlert = false
 
-//	private let settingsHandler = SettingsHandler()
+    private let settingsHandler = SettingsHandler()
+	private let albireoV2PageSize = 24
+	private var albireoV2CurrentFunc: FuncViewModel?
+	private var albireoV2CurrentSearchKeyword = ""
+	private var albireoV2NextOffset = 0
+	private var albireoV2CanLoadMore = false
 
     private func updateBGMList(list:[BangumiItemModel]){
         print("setting \(list.count) objects")
@@ -28,10 +34,16 @@ class BangumiListViewController: ObservableObject{
     
     func getBGMList(funcType:FuncViewModel?, searchKeyword:String){
         if let type = funcType{
+			settingsHandler.registerSettings()
             isAlbireoLoginValid { result in
                 if result{
 					DispatchQueue.main.async {
 						self.isLoading = true
+					}
+					if self.settingsHandler.getAlbireoAuthMode() == .albireoV2OAuth {
+						self.resetAlbireoV2Pagination(funcType: type, searchKeyword: searchKeyword)
+						self.getAlbireoV2DebugList(funcType: type, searchKeyword: searchKeyword)
+						return
 					}
                     switch type {
                     case .mybangumi:
@@ -71,12 +83,141 @@ class BangumiListViewController: ObservableObject{
                 }
             }
             
-        }
-    }
+		}
+	}
+
+	func loadNextPageIfNeeded(currentItem: BangumiItemModel?) {
+		guard settingsHandler.getAlbireoAuthMode() == .albireoV2OAuth,
+			  albireoV2CanLoadMore,
+			  isLoading == false,
+			  isLoadingNextPage == false,
+			  let funcType = albireoV2CurrentFunc,
+			  funcType == .allbangumi || funcType == .search,
+			  let currentItem,
+			  bgmList.last?.id == currentItem.id else {
+			return
+		}
+
+		loadAlbireoV2BangumiPage(funcType: funcType, searchKeyword: albireoV2CurrentSearchKeyword, append: true)
+	}
+
+	private func resetAlbireoV2Pagination(funcType: FuncViewModel, searchKeyword: String) {
+		albireoV2CurrentFunc = funcType
+		albireoV2CurrentSearchKeyword = searchKeyword
+		albireoV2NextOffset = 0
+		albireoV2CanLoadMore = false
+	}
     
+	private func getAlbireoV2DebugList(funcType: FuncViewModel, searchKeyword: String) {
+		let completion: (Bool, Any) -> Void = { result, data in
+			guard result else {
+				DispatchQueue.main.async {
+					self.isLoading = false
+				}
+				print("Albireo V2 list request failed: \(data)")
+				return
+			}
+
+			guard let responseData = data as? Data else {
+				DispatchQueue.main.async {
+					self.isLoading = false
+				}
+				print("Albireo V2 list response is not Data: \(data)")
+				return
+			}
+
+			do {
+				let list = try decodeAlbireoV2BangumiItems(from: responseData)
+				if let firstItem = list.first {
+					print("Albireo V2 decoded list count: \(list.count), first: \(firstItem.id), \(firstItem.name ?? ""), favorite_status: \(String(describing: firstItem.favorite_status))")
+				} else {
+					print("Albireo V2 decoded list count: 0")
+				}
+				self.updateBGMList(list: list)
+			} catch {
+				DispatchQueue.main.async {
+					self.isLoading = false
+				}
+				let responseText = String(data: responseData, encoding: .utf8) ?? ""
+				print("Albireo V2 list decode failed: \(error.localizedDescription), response: \(responseText)")
+			}
+		}
+
+		switch funcType {
+		case .mybangumi:
+			getAlbireoV2FavoriteList(status: .watching, completion: completion)
+		case .onair:
+			getAlbireoV2OnAirList(completion: completion)
+		case .history:
+			self.resultHandler(result: true, data: readPlaybackHistory(), saveTopShelf: false)
+		case .search:
+			loadAlbireoV2BangumiPage(funcType: funcType, searchKeyword: searchKeyword, append: false)
+		case .allbangumi:
+			loadAlbireoV2BangumiPage(funcType: funcType, searchKeyword: searchKeyword, append: false)
+		}
+	}
+
+	private func loadAlbireoV2BangumiPage(funcType: FuncViewModel, searchKeyword: String, append: Bool) {
+		DispatchQueue.main.async {
+			if append {
+				self.isLoadingNextPage = true
+			} else {
+				self.isLoading = true
+			}
+		}
+
+		getAlbireoV2BangumiList(
+			keyword: searchKeyword,
+			offset: append ? albireoV2NextOffset : 0,
+			limit: albireoV2PageSize
+		) { result, data in
+			guard result else {
+				DispatchQueue.main.async {
+					self.isLoading = false
+					self.isLoadingNextPage = false
+				}
+				print("Albireo V2 paged bangumi request failed: \(data)")
+				return
+			}
+
+			guard let responseData = data as? Data else {
+				DispatchQueue.main.async {
+					self.isLoading = false
+					self.isLoadingNextPage = false
+				}
+				print("Albireo V2 paged bangumi response is not Data: \(data)")
+				return
+			}
+
+			do {
+				let list = try decodeAlbireoV2BangumiItems(from: responseData)
+				DispatchQueue.main.async {
+					if append {
+						let existingIDs = Set(self.bgmList.map { $0.id })
+						self.bgmList.append(contentsOf: list.filter { existingIDs.contains($0.id) == false })
+					} else {
+						self.bgmList = list
+					}
+					self.albireoV2NextOffset = (append ? self.albireoV2NextOffset : 0) + list.count
+					self.albireoV2CanLoadMore = list.count >= self.albireoV2PageSize
+					self.isLoading = false
+					self.isLoadingNextPage = false
+					print("Albireo V2 loaded page count: \(list.count), total: \(self.bgmList.count), canLoadMore: \(self.albireoV2CanLoadMore)")
+				}
+			} catch {
+				DispatchQueue.main.async {
+					self.isLoading = false
+					self.isLoadingNextPage = false
+				}
+				let responseText = String(data: responseData, encoding: .utf8) ?? ""
+				print("Albireo V2 paged bangumi decode failed: \(error.localizedDescription), response: \(responseText)")
+			}
+		}
+	}
+
     private func resultHandler(result:Bool, data:Any?, saveTopShelf:Bool){
         if !result{
-            print("login failed, cookie expired")
+            print("Albireo login failed, cookie expired")
             DispatchQueue.main.async {
                 self.isLoading = false
             }

--- a/moe.TV/Controller/DebugViewController.swift
+++ b/moe.TV/Controller/DebugViewController.swift
@@ -22,6 +22,34 @@ class DebugViewController: ObservableObject {
     func getBGMExpireTimeDEBUG() -> Int {
         return settings.getBGMTVExpireTime()
     }
+
+	func getAlbireoAuthModeDEBUG() -> String {
+		settings.getAlbireoAuthMode().rawValue
+	}
+
+	func getAlbireoV2AuthorizationServerURLDEBUG() -> String {
+		settings.getAlbireoV2AuthorizationServerURL()
+	}
+
+	func getAlbireoV2APIServerURLDEBUG() -> String {
+		settings.getAlbireoV2APIServerURL()
+	}
+
+	func getAlbireoV2AccessTokenDEBUG() -> String {
+		settings.getAlbireoV2AccessToken()
+	}
+
+	func getAlbireoV2RefreshTokenDEBUG() -> String {
+		settings.getAlbireoV2RefreshToken()
+	}
+
+	func getAlbireoV2IDTokenDEBUG() -> String {
+		settings.getAlbireoV2IDToken()
+	}
+
+	func getAlbireoV2ExpireTimeDEBUG() -> Int {
+		settings.getAlbireoV2ExpireTime()
+	}
     
     func reSyncBGM(){
 		saveBGMLoginInfo(username: settings.getBGMTVUsername(),

--- a/moe.TV/Controller/LoginViewController.swift
+++ b/moe.TV/Controller/LoginViewController.swift
@@ -12,15 +12,19 @@ import AuthenticationServices
 class LoginViewController: ObservableObject {
     @Published var server = ""
     @Published var username = ""
-    @Published var password = ""
+	@Published var password = ""
 	@Published var albireoV2AuthorizationServer = albireoV2DefaultAuthorizationServerURL
 	@Published var albireoV2APIServer = albireoV2DefaultAPIServerURL
+	@Published var albireoV2OAuthClientID = albireoV2ClientID
+	@Published var albireoV2OAuthRedirectHost = albireoV2RedirectHost
     
     @Published var isValidServer = false
     @Published var isValidUsername = false
     @Published var isValidPassword = false
 	@Published var isValidAlbireoV2AuthorizationServer = true
 	@Published var isValidAlbireoV2APIServer = true
+	@Published var isValidAlbireoV2ClientID = !albireoV2ClientID.isEmpty
+	@Published var isValidAlbireoV2RedirectHost = !albireoV2RedirectHost.isEmpty
     @Published var isLoginButtonTapped = false
     @Published var showError = false
 	@Published var errorMessage = "Server URL or Username / Password error."
@@ -65,11 +69,14 @@ class LoginViewController: ObservableObject {
 		toggleErrorView(msg: "Albireo OAuth2 login is not available on tvOS. Please log in on another device and enable iCloud sync.")
 		return
 		#else
-		guard isValidAlbireoV2AuthorizationServer, isValidAlbireoV2APIServer else {
-			toggleErrorView(msg: "Albireo V2 server URL is invalid.")
+		guard isValidAlbireoV2AuthorizationServer,
+			  isValidAlbireoV2APIServer,
+			  isValidAlbireoV2ClientID,
+			  isValidAlbireoV2RedirectHost else {
+			toggleErrorView(msg: "Albireo V2 OAuth settings are invalid.")
 			return
 		}
-		saveAlbireoV2ServerURLs()
+		saveAlbireoV2OAuthSettings()
 		startAlbireoV2Login { result, message in
 			if result {
 				getAlbireoV2UserInfo { accountResult, accountData in
@@ -94,11 +101,13 @@ class LoginViewController: ObservableObject {
 		#endif
 	}
 
-	private func saveAlbireoV2ServerURLs() {
+	private func saveAlbireoV2OAuthSettings() {
 		let settingsHandler = SettingsHandler()
 		settingsHandler.registerSettings()
 		settingsHandler.setAlbireoV2AuthorizationServerURL(normalizedAlbireoV2LoginURL(albireoV2AuthorizationServer))
 		settingsHandler.setAlbireoV2APIServerURL(normalizedAlbireoV2LoginURL(albireoV2APIServer))
+		settingsHandler.setAlbireoV2ClientID(albireoV2OAuthClientID.trimmingCharacters(in: .whitespacesAndNewlines))
+		settingsHandler.setAlbireoV2RedirectHost(normalizedAlbireoV2RedirectHost(albireoV2OAuthRedirectHost))
 	}
     
     init(){
@@ -109,8 +118,16 @@ class LoginViewController: ObservableObject {
 		}
 		let savedAlbireoV2AuthorizationServer = settingsHandler.getAlbireoV2AuthorizationServerURL()
 		let savedAlbireoV2APIServer = settingsHandler.getAlbireoV2APIServerURL()
+		let savedAlbireoV2ClientID = settingsHandler.getAlbireoV2ClientID()
+		let savedAlbireoV2RedirectHost = settingsHandler.getAlbireoV2RedirectHost()
 		self.albireoV2AuthorizationServer = savedAlbireoV2AuthorizationServer.isEmpty ? albireoV2DefaultAuthorizationServerURL : savedAlbireoV2AuthorizationServer
 		self.albireoV2APIServer = savedAlbireoV2APIServer.isEmpty ? albireoV2DefaultAPIServerURL : savedAlbireoV2APIServer
+		self.albireoV2OAuthClientID = savedAlbireoV2ClientID.isEmpty ? albireoV2ClientID : savedAlbireoV2ClientID
+		self.albireoV2OAuthRedirectHost = savedAlbireoV2RedirectHost.isEmpty ? albireoV2RedirectHost : savedAlbireoV2RedirectHost
+		self.isValidAlbireoV2AuthorizationServer = normalizedAlbireoV2LoginURL(self.albireoV2AuthorizationServer).isValidURL && !self.albireoV2AuthorizationServer.isEmpty
+		self.isValidAlbireoV2APIServer = normalizedAlbireoV2LoginURL(self.albireoV2APIServer).isValidURL && !self.albireoV2APIServer.isEmpty
+		self.isValidAlbireoV2ClientID = !self.albireoV2OAuthClientID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+		self.isValidAlbireoV2RedirectHost = !normalizedAlbireoV2RedirectHost(self.albireoV2OAuthRedirectHost).isEmpty
         $server.sink(receiveValue: {
             self.isValidServer = $0.isValidURL && !$0.isEmpty ? true : false
         }).store(in: &disposables)
@@ -121,6 +138,14 @@ class LoginViewController: ObservableObject {
 
 		$albireoV2APIServer.sink(receiveValue: {
 			self.isValidAlbireoV2APIServer = normalizedAlbireoV2LoginURL($0).isValidURL && !$0.isEmpty
+		}).store(in: &disposables)
+
+		$albireoV2OAuthClientID.sink(receiveValue: {
+			self.isValidAlbireoV2ClientID = !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+		}).store(in: &disposables)
+
+		$albireoV2OAuthRedirectHost.sink(receiveValue: {
+			self.isValidAlbireoV2RedirectHost = !normalizedAlbireoV2RedirectHost($0).isEmpty
 		}).store(in: &disposables)
         
         $username.sink(receiveValue: {
@@ -165,4 +190,14 @@ private func normalizedAlbireoV2LoginURL(_ rawValue: String) -> String {
 		value = "https://\(value)"
 	}
 	return value
+}
+
+private func normalizedAlbireoV2RedirectHost(_ rawValue: String) -> String {
+	let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+	if let url = URL(string: value), let host = url.host, !host.isEmpty {
+		return host
+	}
+	return value
+		.replacingOccurrences(of: "moetv://", with: "")
+		.trimmingCharacters(in: CharacterSet(charactersIn: "/").union(.whitespacesAndNewlines))
 }

--- a/moe.TV/Controller/LoginViewController.swift
+++ b/moe.TV/Controller/LoginViewController.swift
@@ -13,10 +13,14 @@ class LoginViewController: ObservableObject {
     @Published var server = ""
     @Published var username = ""
     @Published var password = ""
+	@Published var albireoV2AuthorizationServer = albireoV2DefaultAuthorizationServerURL
+	@Published var albireoV2APIServer = albireoV2DefaultAPIServerURL
     
     @Published var isValidServer = false
     @Published var isValidUsername = false
     @Published var isValidPassword = false
+	@Published var isValidAlbireoV2AuthorizationServer = true
+	@Published var isValidAlbireoV2APIServer = true
     @Published var isLoginButtonTapped = false
     @Published var showError = false
 	@Published var errorMessage = "Server URL or Username / Password error."
@@ -55,14 +59,69 @@ class LoginViewController: ObservableObject {
             }
         }
     }
+
+	func loginWithAlbireoV2() {
+		#if os(tvOS)
+		toggleErrorView(msg: "Albireo OAuth2 login is not available on tvOS. Please log in on another device and enable iCloud sync.")
+		return
+		#else
+		guard isValidAlbireoV2AuthorizationServer, isValidAlbireoV2APIServer else {
+			toggleErrorView(msg: "Albireo V2 server URL is invalid.")
+			return
+		}
+		saveAlbireoV2ServerURLs()
+		startAlbireoV2Login { result, message in
+			if result {
+				getAlbireoV2UserInfo { accountResult, accountData in
+					DispatchQueue.main.async {
+						if accountResult {
+							self.isLoginSuccessd = true
+							if let data = accountData as? Data,
+							   let text = String(data: data, encoding: .utf8) {
+								print("Albireo V2 user info: \(text)")
+							}
+						} else {
+							self.toggleErrorView(msg: "\(message)\n\(accountData)")
+						}
+					}
+				}
+			} else {
+				DispatchQueue.main.async {
+					self.toggleErrorView(msg: message)
+				}
+			}
+		}
+		#endif
+	}
+
+	private func saveAlbireoV2ServerURLs() {
+		let settingsHandler = SettingsHandler()
+		settingsHandler.registerSettings()
+		settingsHandler.setAlbireoV2AuthorizationServerURL(normalizedAlbireoV2LoginURL(albireoV2AuthorizationServer))
+		settingsHandler.setAlbireoV2APIServerURL(normalizedAlbireoV2LoginURL(albireoV2APIServer))
+	}
     
     init(){
+		let settingsHandler = SettingsHandler()
+		settingsHandler.registerSettings()
 		if let Aserver = getAlbireoServer(){
 			self.server = Aserver
 		}
+		let savedAlbireoV2AuthorizationServer = settingsHandler.getAlbireoV2AuthorizationServerURL()
+		let savedAlbireoV2APIServer = settingsHandler.getAlbireoV2APIServerURL()
+		self.albireoV2AuthorizationServer = savedAlbireoV2AuthorizationServer.isEmpty ? albireoV2DefaultAuthorizationServerURL : savedAlbireoV2AuthorizationServer
+		self.albireoV2APIServer = savedAlbireoV2APIServer.isEmpty ? albireoV2DefaultAPIServerURL : savedAlbireoV2APIServer
         $server.sink(receiveValue: {
             self.isValidServer = $0.isValidURL && !$0.isEmpty ? true : false
         }).store(in: &disposables)
+
+		$albireoV2AuthorizationServer.sink(receiveValue: {
+			self.isValidAlbireoV2AuthorizationServer = normalizedAlbireoV2LoginURL($0).isValidURL && !$0.isEmpty
+		}).store(in: &disposables)
+
+		$albireoV2APIServer.sink(receiveValue: {
+			self.isValidAlbireoV2APIServer = normalizedAlbireoV2LoginURL($0).isValidURL && !$0.isEmpty
+		}).store(in: &disposables)
         
         $username.sink(receiveValue: {
             self.isValidUsername = !$0.isEmpty ? true : false
@@ -95,4 +154,15 @@ class LoginViewController: ObservableObject {
                     })
                     .store(in: &disposables)
     }
+}
+
+private func normalizedAlbireoV2LoginURL(_ rawValue: String) -> String {
+	var value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+	while value.hasSuffix("/") {
+		value.removeLast()
+	}
+	if !value.contains("://") {
+		value = "https://\(value)"
+	}
+	return value
 }

--- a/moe.TV/Models/APIModel/AlbireoV2/AlbireoV2Model.swift
+++ b/moe.TV/Models/APIModel/AlbireoV2/AlbireoV2Model.swift
@@ -1,0 +1,517 @@
+//
+//  AlbireoV2Model.swift
+//  moe.TV
+//
+
+import Foundation
+
+private let albireoV2ModelJSONDecoder = JSONDecoder()
+
+enum AlbireoV2FavoriteStatus: String, CaseIterable {
+	case watching = "WATCHING"
+	case wish = "WISH"
+	case watched = "WATCHED"
+	case pause = "PAUSE"
+	case abandoned = "ABANDONED"
+
+	var legacyValue: Int {
+		switch self {
+		case .wish:
+			return 1
+		case .watched:
+			return 2
+		case .watching:
+			return 3
+		case .pause:
+			return 4
+		case .abandoned:
+			return 5
+		}
+	}
+
+	init?(legacyValue: Int) {
+		switch legacyValue {
+		case 1:
+			self = .wish
+		case 2:
+			self = .watched
+		case 3:
+			self = .watching
+		case 4:
+			self = .pause
+		case 5:
+			self = .abandoned
+		default:
+			return nil
+		}
+	}
+}
+
+struct AlbireoV2OAuthTokenResponse: Decodable {
+	let accessToken: String
+	let refreshToken: String?
+	let idToken: String?
+	let expiresIn: Int?
+	let tokenType: String?
+	let scope: String?
+
+	enum CodingKeys: String, CodingKey {
+		case accessToken = "access_token"
+		case refreshToken = "refresh_token"
+		case idToken = "id_token"
+		case expiresIn = "expires_in"
+		case tokenType = "token_type"
+		case scope
+	}
+}
+
+struct AlbireoV2BangumiListResponse: Decodable {
+	let data: [AlbireoV2BangumiItem]
+}
+
+struct AlbireoV2FavoriteListResponse: Decodable {
+	let data: [AlbireoV2FavoriteItem]
+}
+
+struct AlbireoV2FavoriteItem: Decodable {
+	let bangumi: AlbireoV2BangumiItem?
+	let unwatchedCount: Int?
+	let status: String?
+
+	func toBangumiItemModel() -> BangumiItemModel? {
+		guard var model = bangumi?.toBangumiItemModel() else {
+			return nil
+		}
+		model.unwatched_count = unwatchedCount ?? model.unwatched_count
+		if let status, let favoriteStatus = AlbireoV2FavoriteStatus(rawValue: status) {
+			model.favorite_status = favoriteStatus.legacyValue
+		}
+		return model
+	}
+}
+
+struct AlbireoV2FavoriteInfo: Decodable {
+	let status: String?
+}
+
+struct AlbireoV2BangumiItem: Decodable {
+	let id: String
+	let bgmId: Int?
+	let name: String?
+	let nameCn: String?
+	let summary: String?
+	let airDate: String?
+	let airWeekday: Int?
+	let type: Int?
+	let status: Int?
+	let subType: String?
+	let eps: Int?
+	let favoriteStatus: String?
+	let unwatchedCount: Int?
+	let coverImage: AlbireoV2CoverImage?
+	let episodes: [AlbireoV2EpisodeItem]?
+	let favorite: AlbireoV2FavoriteInfo?
+	let itemId: String?
+
+	enum CodingKeys: String, CodingKey {
+		case id
+		case bgmId
+		case name
+		case nameCn
+		case summary
+		case airDate
+		case airWeekday
+		case type
+		case status
+		case subType
+		case eps
+		case favoriteStatus
+		case unwatchedCount
+		case coverImage
+		case episodes
+		case bangumiEpisodes
+		case itemEpisodes
+		case items
+		case favorite
+		case itemId
+	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		id = try container.decode(String.self, forKey: .id)
+		bgmId = decodeAlbireoV2OptionalInt(container, forKey: .bgmId)
+		name = try container.decodeIfPresent(String.self, forKey: .name)
+		nameCn = try container.decodeIfPresent(String.self, forKey: .nameCn)
+		summary = try container.decodeIfPresent(String.self, forKey: .summary)
+		airDate = try container.decodeIfPresent(String.self, forKey: .airDate)
+		airWeekday = decodeAlbireoV2OptionalInt(container, forKey: .airWeekday)
+		type = decodeAlbireoV2BangumiType(container, forKey: .type)
+		status = decodeAlbireoV2OptionalInt(container, forKey: .status)
+		subType = try container.decodeIfPresent(String.self, forKey: .subType)
+		eps = decodeAlbireoV2OptionalInt(container, forKey: .eps)
+		unwatchedCount = decodeAlbireoV2OptionalInt(container, forKey: .unwatchedCount)
+		coverImage = try container.decodeIfPresent(AlbireoV2CoverImage.self, forKey: .coverImage)
+		episodes = decodeAlbireoV2EpisodeItems(container)
+		favorite = try container.decodeIfPresent(AlbireoV2FavoriteInfo.self, forKey: .favorite)
+		itemId = try container.decodeIfPresent(String.self, forKey: .itemId)
+		let explicitFavoriteStatus = try container.decodeIfPresent(String.self, forKey: .favoriteStatus)
+		let statusString = try? container.decodeIfPresent(String.self, forKey: .status)
+		favoriteStatus = favorite?.status ?? explicitFavoriteStatus ?? statusString
+	}
+
+	func toBangumiItemModel() -> BangumiItemModel {
+		var model = BangumiItemModel(
+			id: id,
+			bgm_id: bgmId,
+			name: name,
+			name_cn: nameCn ?? "",
+			summary: summary ?? "",
+			image: coverImage?.url ?? "",
+			type: type ?? 2,
+			status: status ?? 0,
+			air_weekday: airWeekday,
+			eps: eps ?? 0,
+			favorite_status: nil,
+			unwatched_count: unwatchedCount ?? 0
+		)
+		if let favoriteStatus, let status = AlbireoV2FavoriteStatus(rawValue: favoriteStatus) {
+			model.favorite_status = status.legacyValue
+		}
+		return model
+	}
+
+	func toEPBangumiModel() -> EPbangumiModel {
+		EPbangumiModel(
+			id: id,
+			bgm_id: bgmId,
+			name: name,
+			name_cn: nameCn ?? "",
+			summary: summary ?? "",
+			image: coverImage?.url ?? "",
+			type: type ?? 2,
+			status: status ?? 0,
+			air_weekday: airWeekday,
+			eps: eps ?? 0
+		)
+	}
+}
+
+struct AlbireoV2CoverImage: Decodable {
+	let id: String?
+	let width: Int?
+	let height: Int?
+	let dominantColor: String?
+	let url: String?
+}
+
+struct AlbireoV2BangumiDetailResponse: Decodable {
+	let data: AlbireoV2BangumiItem?
+
+	init(from decoder: Decoder) throws {
+		let container = try? decoder.container(keyedBy: CodingKeys.self)
+		if let wrappedData = try container?.decodeIfPresent(AlbireoV2BangumiItem.self, forKey: .data) {
+			data = wrappedData
+		} else {
+			data = try AlbireoV2BangumiItem(from: decoder)
+		}
+	}
+
+	enum CodingKeys: String, CodingKey {
+		case data
+	}
+}
+
+
+struct AlbireoV2EpisodeListResponse: Decodable {
+	let data: [AlbireoV2EpisodeItem]
+}
+
+struct AlbireoV2EpisodeItem: Decodable {
+	let id: String
+	let bangumiId: String?
+	let bgmEpsId: Int?
+	let name: String?
+	let nameCn: String?
+	let thumbnail: String?
+	let status: Int?
+	let episodeNo: Int?
+	let duration: String?
+	let videoFiles: [videoFilesListModel]?
+	let bangumi: AlbireoV2BangumiItem?
+	let thumbnailImage: AlbireoV2CoverImage?
+	let progress: watchProgress?
+
+	enum CodingKeys: String, CodingKey {
+		case id
+		case bangumiId
+		case bangumiID
+		case bgmEpsId
+		case name
+		case nameCn
+		case thumbnail
+		case status
+		case episodeNo
+		case duration
+		case videoFiles
+		case video_files
+		case bangumi
+		case thumbnailImage
+		case watchProgress
+		case watch_progress
+	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		id = try container.decode(String.self, forKey: .id)
+		bangumiId = try container.decodeIfPresent(String.self, forKey: .bangumiId) ?? container.decodeIfPresent(String.self, forKey: .bangumiID)
+		bgmEpsId = decodeAlbireoV2OptionalInt(container, forKey: .bgmEpsId)
+		name = try container.decodeIfPresent(String.self, forKey: .name)
+		nameCn = try container.decodeIfPresent(String.self, forKey: .nameCn)
+		thumbnail = try container.decodeIfPresent(String.self, forKey: .thumbnail)
+		status = decodeAlbireoV2OptionalInt(container, forKey: .status)
+		episodeNo = decodeAlbireoV2OptionalInt(container, forKey: .episodeNo)
+		if let stringDuration = try? container.decodeIfPresent(String.self, forKey: .duration) {
+			duration = stringDuration
+		} else if let intDuration = try? container.decodeIfPresent(Int.self, forKey: .duration) {
+			duration = String(intDuration)
+		} else {
+			duration = nil
+		}
+		videoFiles = try container.decodeIfPresent([videoFilesListModel].self, forKey: .videoFiles) ?? container.decodeIfPresent([videoFilesListModel].self, forKey: .video_files)
+		bangumi = try container.decodeIfPresent(AlbireoV2BangumiItem.self, forKey: .bangumi)
+		thumbnailImage = try container.decodeIfPresent(AlbireoV2CoverImage.self, forKey: .thumbnailImage)
+		if let v2Progress = try container.decodeIfPresent(AlbireoV2WatchProgress.self, forKey: .watchProgress) {
+			progress = v2Progress.toWatchProgress(defaultBangumiId: bangumiId, defaultEpisodeId: id)
+		} else {
+			progress = try container.decodeIfPresent(watchProgress.self, forKey: .watch_progress)
+		}
+	}
+
+	func toBGMEpisode(defaultBangumiId: String) -> BGMEpisode {
+		BGMEpisode(
+			id: id,
+			bangumi_id: bangumiId ?? bangumi?.id ?? defaultBangumiId,
+			bgm_eps_id: bgmEpsId,
+			name: name,
+			name_cn: nameCn ?? "",
+			thumbnail: thumbnail ?? thumbnailImage?.url,
+			status: status ?? 0,
+			episode_no: episodeNo,
+			duration: duration,
+			watch_progress: progress
+		)
+	}
+
+	func toEpisodeDetailModel(defaultBangumiId: String) -> EpisodeDetailModel {
+		let bgmEpisode = toBGMEpisode(defaultBangumiId: defaultBangumiId)
+		return EpisodeDetailModel(
+			id: bgmEpisode.id,
+			bangumi_id: bgmEpisode.bangumi_id,
+			bgm_eps_id: bgmEpisode.bgm_eps_id,
+			name: bgmEpisode.name,
+			name_cn: bgmEpisode.name_cn,
+			summary: "",
+			thumbnail: bgmEpisode.thumbnail,
+			status: bgmEpisode.status,
+			episode_no: bgmEpisode.episode_no,
+			duration: bgmEpisode.duration,
+			bangumi: bangumi?.toEPBangumiModel(),
+			video_files: videoFiles,
+			watch_progress: progress
+		)
+	}
+}
+
+struct AlbireoV2Reference: Decodable {
+	let id: String?
+}
+
+struct AlbireoV2WatchProgress: Decodable {
+	let id: String
+	let userId: String?
+	let watchStatus: Int?
+	let lastWatchPosition: Double?
+	let percentage: Float?
+	let bangumi: AlbireoV2Reference?
+	let episode: AlbireoV2Reference?
+
+	enum CodingKeys: String, CodingKey {
+		case id
+		case userId
+		case watchStatus
+		case lastWatchPosition
+		case percentage
+		case bangumi
+		case episode
+	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		id = try container.decode(String.self, forKey: .id)
+		userId = try container.decodeIfPresent(String.self, forKey: .userId)
+		watchStatus = decodeAlbireoV2OptionalInt(container, forKey: .watchStatus)
+		lastWatchPosition = decodeAlbireoV2OptionalDouble(container, forKey: .lastWatchPosition)
+		percentage = decodeAlbireoV2OptionalFloat(container, forKey: .percentage)
+		bangumi = try container.decodeIfPresent(AlbireoV2Reference.self, forKey: .bangumi)
+		episode = try container.decodeIfPresent(AlbireoV2Reference.self, forKey: .episode)
+	}
+
+	func toWatchProgress(defaultBangumiId: String?, defaultEpisodeId: String?) -> watchProgress {
+		watchProgress(
+			id: id,
+			user_id: userId,
+			last_watch_position: lastWatchPosition,
+			bangumi_id: bangumi?.id ?? defaultBangumiId,
+			watch_status: watchStatus,
+			episode_id: episode?.id ?? defaultEpisodeId,
+			percentage: percentage
+		)
+	}
+}
+
+private func decodeAlbireoV2EpisodeItems(_ container: KeyedDecodingContainer<AlbireoV2BangumiItem.CodingKeys>) -> [AlbireoV2EpisodeItem]? {
+	for key in [AlbireoV2BangumiItem.CodingKeys.episodes, .bangumiEpisodes, .itemEpisodes, .items] {
+		if let episodes = try? container.decodeIfPresent([AlbireoV2EpisodeItem].self, forKey: key) {
+			return episodes
+		}
+	}
+	return nil
+}
+
+private func decodeAlbireoV2OptionalDouble<Key: CodingKey>(_ container: KeyedDecodingContainer<Key>, forKey key: Key) -> Double? {
+	if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
+		return value
+	}
+	if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
+		return Double(value)
+	}
+	if let value = try? container.decodeIfPresent(String.self, forKey: key) {
+		return Double(value)
+	}
+	return nil
+}
+
+private func decodeAlbireoV2OptionalFloat<Key: CodingKey>(_ container: KeyedDecodingContainer<Key>, forKey key: Key) -> Float? {
+	if let value = try? container.decodeIfPresent(Float.self, forKey: key) {
+		return value
+	}
+	if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
+		return Float(value)
+	}
+	if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
+		return Float(value)
+	}
+	if let value = try? container.decodeIfPresent(String.self, forKey: key) {
+		return Float(value)
+	}
+	return nil
+}
+
+private func decodeAlbireoV2OptionalInt<Key: CodingKey>(_ container: KeyedDecodingContainer<Key>, forKey key: Key) -> Int? {
+	if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
+		return value
+	}
+	if let value = try? container.decodeIfPresent(String.self, forKey: key) {
+		return Int(value)
+	}
+	return nil
+}
+
+private func decodeAlbireoV2BangumiType<Key: CodingKey>(_ container: KeyedDecodingContainer<Key>, forKey key: Key) -> Int? {
+	if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
+		return value
+	}
+	guard let value = try? container.decodeIfPresent(String.self, forKey: key) else {
+		return nil
+	}
+	switch value.lowercased() {
+	case "anime":
+		return 2
+	default:
+		return 0
+	}
+}
+
+func decodeAlbireoV2BangumiItems(from data: Data) throws -> [BangumiItemModel] {
+	if let response = try? albireoV2ModelJSONDecoder.decode(AlbireoV2FavoriteListResponse.self, from: data) {
+		let list = response.data.compactMap { $0.toBangumiItemModel() }
+		if list.isEmpty == false {
+			return list
+		}
+	}
+
+	if let response = try? albireoV2ModelJSONDecoder.decode(AlbireoV2BangumiListResponse.self, from: data) {
+		return response.data.map { $0.toBangumiItemModel() }
+	}
+
+	throw DecodingError.dataCorrupted(
+		DecodingError.Context(
+			codingPath: [],
+			debugDescription: "Unsupported Albireo V2 bangumi list response."
+		)
+	)
+}
+
+func decodeAlbireoV2BangumiDetail(from data: Data) throws -> BangumiDetailModel {
+	let response = try albireoV2ModelJSONDecoder.decode(AlbireoV2BangumiDetailResponse.self, from: data)
+	guard let item = response.data else {
+		throw DecodingError.dataCorrupted(
+			DecodingError.Context(codingPath: [], debugDescription: "Albireo V2 bangumi detail response data is empty.")
+		)
+	}
+	let listItem = item.toBangumiItemModel()
+	let episodes = item.episodes?.map { episode in
+		episode.toBGMEpisode(defaultBangumiId: item.id)
+	} ?? []
+	return BangumiDetailModel(
+		id: listItem.id,
+		bgm_id: listItem.bgm_id,
+		name: listItem.name,
+		name_cn: listItem.name_cn,
+		summary: listItem.summary,
+		image: listItem.image,
+		type: listItem.type,
+		status: listItem.status,
+		air_weekday: listItem.air_weekday,
+		eps: listItem.eps,
+		favorite_status: listItem.favorite_status,
+		episodes: episodes
+	)
+}
+
+func decodeAlbireoV2Episodes(from data: Data, defaultBangumiId: String) throws -> [BGMEpisode] {
+	if let response = try? albireoV2ModelJSONDecoder.decode(AlbireoV2EpisodeListResponse.self, from: data) {
+		return response.data.map { $0.toBGMEpisode(defaultBangumiId: defaultBangumiId) }
+	}
+
+	if let response = try? albireoV2ModelJSONDecoder.decode([AlbireoV2EpisodeItem].self, from: data) {
+		return response.map { $0.toBGMEpisode(defaultBangumiId: defaultBangumiId) }
+	}
+
+	throw DecodingError.dataCorrupted(
+		DecodingError.Context(
+			codingPath: [],
+			debugDescription: "Unsupported Albireo V2 episode list response."
+		)
+	)
+}
+
+func decodeAlbireoV2EpisodeDetail(from data: Data, defaultBangumiId: String) throws -> EpisodeDetailModel {
+	if let response = try? albireoV2ModelJSONDecoder.decode(AlbireoV2EpisodeItem.self, from: data) {
+		return response.toEpisodeDetailModel(defaultBangumiId: defaultBangumiId)
+	}
+
+	throw DecodingError.dataCorrupted(
+		DecodingError.Context(
+			codingPath: [],
+			debugDescription: "Unsupported Albireo V2 episode detail response."
+		)
+	)
+}
+
+func albireoV2TopLevelKeys(from data: Data) -> [String] {
+	guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+		return []
+	}
+	return object.keys.sorted()
+}

--- a/moe.TV/Shared/AlbireoServerHandler.swift
+++ b/moe.TV/Shared/AlbireoServerHandler.swift
@@ -25,6 +25,7 @@ func saveAlbireoCookies(response: HTTPURLResponse) {
     }
     if cookieArray.count > 0{
         settingsHandler.setAlbireoCookie(array: cookieArray)
+		settingsHandler.setAlbireoAuthMode(.legacyCookie)
         print("albireo cookie saved")
     }else{
         print("albireo cookie is empty, skip")
@@ -69,10 +70,28 @@ func clearCookie(){
     print("albireo cookie cleared")
 }
 
+func isAlbireoAuthenticated() -> Bool {
+	settingsHandler.registerSettings()
+	switch settingsHandler.getAlbireoAuthMode() {
+	case .albireoV2OAuth:
+		return isAlbireoV2Logined()
+	case .legacyCookie:
+		return loadAlbireoCookies()
+	}
+}
+
 func isAlbireoLoginValid(completion: @escaping (Bool) -> Void){
-    getAlbireoUserInfo { result, data in
-        completion(result)
-    }
+	settingsHandler.registerSettings()
+	switch settingsHandler.getAlbireoAuthMode() {
+	case .albireoV2OAuth:
+		getAlbireoV2UserInfo { result, _ in
+			completion(result)
+		}
+	case .legacyCookie:
+		getAlbireoUserInfo { result, data in
+			completion(result)
+		}
+	}
 }
 
 
@@ -208,8 +227,12 @@ func logoutAlbireoServer(completion: @escaping (Bool, String) -> Void) {
 //            completion(false, data as! String)
 //        }
 //    }
-    clearCookie()
-    completion(true, "logout success")
+	settingsHandler.registerSettings()
+	let authMode = settingsHandler.getAlbireoAuthMode()
+	clearCookie()
+	logoutAlbireoV2()
+	print("albireo logout success, previous auth mode: \(authMode.rawValue)")
+	completion(true, "logout success")
 }
 
 func getAlbireoUserInfo(completion: @escaping (Bool, Any?) -> Void){
@@ -368,6 +391,14 @@ func getAlbireoBangumiDetail(id: String,
 }
 func getAlbireoEPDetail(ep_id: String,
                       completion: @escaping (Bool, Any?) -> Void) {
+	settingsHandler.registerSettings()
+	if settingsHandler.getAlbireoAuthMode() == .albireoV2OAuth {
+		getAlbireoV2EpisodeDetail(epID: ep_id) { result, data in
+			completion(result, data)
+		}
+		return
+	}
+
 	if var urlstr = getAlbireoServer(){
 		urlstr.append("/api/home/episode/")
 		urlstr.append(ep_id)
@@ -401,6 +432,19 @@ func sentAlbireoEPWatchProgress(ep_id: String,
                          percentage:Double,
                          is_finished:Bool,
                          completion: @escaping (Bool, Any?) -> Void){
+	settingsHandler.registerSettings()
+	if settingsHandler.getAlbireoAuthMode() == .albireoV2OAuth {
+		syncAlbireoV2EpisodeWatchProgress(
+			epID: ep_id,
+			bangumiID: bangumi_id,
+			lastWatchPosition: last_watch_position,
+			percentage: percentage,
+			isFinished: is_finished,
+			completion: completion
+		)
+		return
+	}
+
 	if var urlstr = getAlbireoServer(){
 		urlstr.append("/api/watch/history/")
 		urlstr.append(ep_id)
@@ -430,6 +474,13 @@ func sentAlbireoEPWatchProgress(ep_id: String,
 func changeAlbireoFavStatus(bangumi_id:String,
                      status:Int,
                      completion: @escaping (Bool, Any?) -> Void){
+	let settingsHandler = SettingsHandler()
+	settingsHandler.registerSettings()
+	if settingsHandler.getAlbireoAuthMode() == .albireoV2OAuth {
+		changeAlbireoV2FavoriteStatus(bangumiID: bangumi_id, status: status, completion: completion)
+		return
+	}
+
 	if var urlstr = getAlbireoServer(){
 		urlstr.append("/api/watch/favorite/bangumi/")
 		urlstr.append(bangumi_id)
@@ -452,4 +503,3 @@ func changeAlbireoFavStatus(bangumi_id:String,
 		completion(false, "Can not get server address.")
 	}
 }
-

--- a/moe.TV/Shared/AlbireoV2ServerHandler.swift
+++ b/moe.TV/Shared/AlbireoV2ServerHandler.swift
@@ -1,0 +1,595 @@
+//
+//  AlbireoV2ServerHandler.swift
+//  moe.TV
+//
+//  Handles Albireo V2 OAuth2 login and API v2 requests.
+//
+
+import CryptoKit
+import Foundation
+
+private let albireoV2SettingsHandler = SettingsHandler()
+private let albireoV2Scopes = "openid offline_access profile bookmark"
+
+private let albireoV2OAuthCodeLock = NSLock()
+private var handledAlbireoV2OAuthCodes = Set<String>()
+private var pendingAlbireoV2OAuthState: String?
+private var pendingAlbireoV2OAuthCodeVerifier: String?
+
+private func currentAlbireoV2RedirectURI() -> String {
+	"moetv://\(albireoV2RedirectHost)"
+}
+
+private func currentAlbireoV2AuthorizationServer() -> String {
+	albireoV2SettingsHandler.registerSettings()
+	return normalizedAlbireoV2ServerURL(
+		albireoV2SettingsHandler.getAlbireoV2AuthorizationServerURL(),
+		fallback: albireoV2DefaultAuthorizationServerURL
+	)
+}
+
+private func currentAlbireoV2APIServer() -> String {
+	albireoV2SettingsHandler.registerSettings()
+	return normalizedAlbireoV2ServerURL(
+		albireoV2SettingsHandler.getAlbireoV2APIServerURL(),
+		fallback: albireoV2DefaultAPIServerURL
+	)
+}
+
+private func currentAlbireoV2APIBaseURL() -> String {
+	let server = currentAlbireoV2APIServer()
+	if server.hasSuffix("/api/v2") {
+		return server
+	}
+	return "\(server)/api/v2"
+}
+
+func isAlbireoV2Logined() -> Bool {
+	albireoV2SettingsHandler.registerSettings()
+	return !albireoV2SettingsHandler.getAlbireoV2AccessToken().isEmpty
+}
+
+func logoutAlbireoV2() {
+	albireoV2SettingsHandler.clearAlbireoV2AuthInfo()
+}
+
+func startAlbireoV2Login(completion: @escaping (Bool, String) -> Void) {
+	guard !albireoV2ClientID.isEmpty else {
+		completion(false, "Albireo V2 client id is empty. Please set albireoV2ClientID in DONOTUPLOAD.swift.")
+		return
+	}
+
+	let codeVerifier = makeAlbireoV2RandomString(length: 64)
+	let codeChallenge = makeAlbireoV2CodeChallenge(verifier: codeVerifier)
+	let state = makeAlbireoV2RandomString(length: 32)
+	pendingAlbireoV2OAuthState = state
+	pendingAlbireoV2OAuthCodeVerifier = codeVerifier
+
+	let authorizationServer = currentAlbireoV2AuthorizationServer()
+	let apiServer = currentAlbireoV2APIServer()
+	var components = URLComponents(string: "\(authorizationServer)/oauth2/auth")
+	components?.queryItems = [
+		URLQueryItem(name: "client_id", value: albireoV2ClientID),
+		URLQueryItem(name: "response_type", value: "code"),
+		URLQueryItem(name: "redirect_uri", value: currentAlbireoV2RedirectURI()),
+		URLQueryItem(name: "scope", value: albireoV2Scopes),
+		URLQueryItem(name: "state", value: state),
+		URLQueryItem(name: "audience", value: apiServer),
+		URLQueryItem(name: "code_challenge", value: codeChallenge),
+		URLQueryItem(name: "code_challenge_method", value: "S256")
+	]
+
+	guard let urlString = components?.url?.absoluteString else {
+		completion(false, "Failed to build Albireo V2 OAuth URL.")
+		return
+	}
+
+	#if os(tvOS)
+	completion(false, "Albireo V2 OAuth login is not available on tvOS.")
+	#else
+	OAuthSessionManager.shared.start(urlString: urlString, callbackScheme: "moetv") { result in
+		switch result {
+		case .success(let callbackURL):
+			print("Albireo V2 OAuth callback URL: \(callbackURL.absoluteString)")
+			if !handleAlbireoV2OAuthCallback(callbackURL, completion: completion) {
+				completion(false, "Albireo V2 OAuth callback missing code.")
+			}
+		case .failure(let error):
+			completion(false, error.localizedDescription)
+		}
+	}
+	#endif
+}
+
+@discardableResult
+func handleAlbireoV2OAuthCallback(_ url: URL, completion: ((Bool, String) -> Void)? = nil) -> Bool {
+	guard url.scheme == "moetv",
+		  url.host == albireoV2RedirectHost,
+		  let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+		  let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
+		  !code.isEmpty else {
+		return false
+	}
+
+	if let returnedState = components.queryItems?.first(where: { $0.name == "state" })?.value,
+	   let expectedState = pendingAlbireoV2OAuthState,
+	   returnedState != expectedState {
+		completion?(false, "Albireo V2 OAuth state mismatch.")
+		return true
+	}
+
+	albireoV2OAuthCodeLock.lock()
+	let isNewCode = handledAlbireoV2OAuthCodes.insert(code).inserted
+	albireoV2OAuthCodeLock.unlock()
+
+	guard isNewCode else {
+		print("Ignoring duplicate Albireo V2 OAuth code callback")
+		completion?(true, "duplicate callback ignored")
+		return true
+	}
+
+	guard let codeVerifier = pendingAlbireoV2OAuthCodeVerifier else {
+		completion?(false, "Albireo V2 OAuth code verifier is missing.")
+		return true
+	}
+
+	getAlbireoV2AccessToken(code: code, codeVerifier: codeVerifier) { isSuccess, result in
+		if isSuccess {
+			NotificationCenter.default.post(name: Notification.Name("getAlbireoV2UserInfo"), object: nil)
+		} else {
+			print("getAlbireoV2AccessToken failed: \(result)")
+		}
+		completion?(isSuccess, result)
+	}
+	return true
+}
+
+func getAlbireoV2AccessToken(code: String, codeVerifier: String, completion: @escaping (Bool, String) -> Void) {
+	let body = [
+		"grant_type": "authorization_code",
+		"client_id": albireoV2ClientID,
+		"code": code,
+		"redirect_uri": currentAlbireoV2RedirectURI(),
+		"code_verifier": codeVerifier
+	]
+	postAlbireoV2TokenRequest(body: body) { isSuccess, result in
+		if isSuccess {
+			pendingAlbireoV2OAuthState = nil
+			pendingAlbireoV2OAuthCodeVerifier = nil
+		}
+		completion(isSuccess, result)
+	}
+}
+
+func refreshAlbireoV2Token(completion: @escaping (Bool, String) -> Void) {
+	let refreshToken = albireoV2SettingsHandler.getAlbireoV2RefreshToken()
+	guard !refreshToken.isEmpty else {
+		completion(false, "Albireo V2 refresh token is empty.")
+		return
+	}
+
+	let body = [
+		"grant_type": "refresh_token",
+		"client_id": albireoV2ClientID,
+		"refresh_token": refreshToken
+	]
+	postAlbireoV2TokenRequest(body: body, completion: completion)
+}
+
+func ensureAlbireoV2AccessTokenValid(completion: @escaping (Bool, String) -> Void) {
+	guard isAlbireoV2Logined() else {
+		completion(false, "Albireo V2 access token is empty.")
+		return
+	}
+
+	let expireTime = albireoV2SettingsHandler.getAlbireoV2ExpireTime()
+	let now = Int(Date().timeIntervalSince1970)
+	if expireTime > now + 120 {
+		completion(true, "Albireo V2 access token is valid.")
+		return
+	}
+
+	refreshAlbireoV2Token(completion: completion)
+}
+
+func getAlbireoV2UserInfo(completion: @escaping (Bool, Any) -> Void) {
+	getAlbireoV2JSON(urlString: "\(currentAlbireoV2AuthorizationServer())/userinfo", completion: completion)
+}
+
+func getAlbireoV2AccountInfo(completion: @escaping (Bool, Any) -> Void) {
+	getAlbireoV2JSON(urlString: "\(currentAlbireoV2APIBaseURL())/account/info", completion: completion)
+}
+
+func getAlbireoV2BangumiDetail(id: String, completion: @escaping (Bool, Any) -> Void) {
+	var components = URLComponents(string: "\(currentAlbireoV2APIBaseURL())/bangumi/\(id)")
+	components?.queryItems = [
+		URLQueryItem(name: "loadEpisodes", value: "true"),
+		URLQueryItem(name: "loadBangumiEpisodes", value: "true"),
+		URLQueryItem(name: "loadFavorite", value: "true")
+	]
+	guard let urlString = components?.url?.absoluteString else {
+		completion(false, "Failed to build Albireo V2 bangumi detail URL.")
+		return
+	}
+	print("Albireo V2 bangumi detail request: \(urlString)")
+	getAlbireoV2JSON(urlString: urlString) { result, data in
+		if let responseData = data as? Data,
+		   let responseText = String(data: responseData, encoding: .utf8) {
+			print("Albireo V2 bangumi detail response: \(responseText)")
+			print("Albireo V2 bangumi detail top-level keys: \(albireoV2TopLevelKeys(from: responseData))")
+		} else {
+			print("Albireo V2 bangumi detail response: \(data)")
+		}
+		completion(result, data)
+	}
+}
+
+func getAlbireoV2EpisodeDetail(epID: String, defaultBangumiID: String? = nil, completion: @escaping (Bool, Any) -> Void) {
+	var components = URLComponents(string: "\(currentAlbireoV2APIBaseURL())/episode/\(epID)")
+	components?.queryItems = [
+		URLQueryItem(name: "loadBangumiEpisodes", value: "true"),
+		URLQueryItem(name: "loadFavorite", value: "true")
+	]
+	guard let urlString = components?.url?.absoluteString else {
+		completion(false, "Failed to build Albireo V2 episode detail URL.")
+		return
+	}
+	print("Albireo V2 episode detail request: \(urlString)")
+	getAlbireoV2JSON(urlString: urlString) { result, data in
+		if let responseData = data as? Data,
+		   let responseText = String(data: responseData, encoding: .utf8) {
+			print("Albireo V2 episode detail response: \(responseText)")
+			if result {
+				do {
+					let episode = try decodeAlbireoV2EpisodeDetail(from: responseData, defaultBangumiId: defaultBangumiID ?? "")
+					completion(true, episode)
+				} catch {
+					completion(false, "Albireo V2 episode detail decode failed: \(error.localizedDescription)")
+				}
+				return
+			}
+		} else {
+			print("Albireo V2 episode detail response: \(data)")
+		}
+		completion(result, data)
+	}
+}
+
+func getAlbireoV2FavoriteList(status: AlbireoV2FavoriteStatus,
+						   offset: Int = 0,
+						   limit: Int = -1,
+						   completion: @escaping (Bool, Any) -> Void) {
+	var components = URLComponents(string: "\(currentAlbireoV2APIBaseURL())/favorite")
+	components?.queryItems = [
+		URLQueryItem(name: "status", value: status.rawValue),
+		URLQueryItem(name: "offset", value: String(offset)),
+		URLQueryItem(name: "limit", value: String(limit)),
+		URLQueryItem(name: "countUnwatched", value: "false"),
+		URLQueryItem(name: "enableEpsUpdateTime", value: "false"),
+		URLQueryItem(name: "orderBy", value: "updateTime"),
+		URLQueryItem(name: "sort", value: "desc"),
+		URLQueryItem(name: "coverImage", value: "false")
+	]
+	performAlbireoV2DebugListRequest(label: "favorite \(status.rawValue)", components: components, completion: completion)
+}
+
+func getAlbireoV2OnAirList(completion: @escaping (Bool, Any) -> Void) {
+	var components = URLComponents(string: "\(currentAlbireoV2APIBaseURL())/bangumi/on-air")
+	components?.queryItems = [
+		URLQueryItem(name: "type", value: "anime")
+	]
+	performAlbireoV2DebugListRequest(label: "on-air", components: components, completion: completion)
+}
+
+func getAlbireoV2BangumiList(keyword: String = "",
+						   offset: Int = 0,
+						   limit: Int = 23,
+						   completion: @escaping (Bool, Any) -> Void) {
+	var components = URLComponents(string: "\(currentAlbireoV2APIBaseURL())/bangumi")
+	var queryItems = [
+		URLQueryItem(name: "offset", value: String(offset)),
+		URLQueryItem(name: "limit", value: String(limit)),
+		URLQueryItem(name: "orderBy", value: keyword.isEmpty ? "air_date" : "airDate"),
+		URLQueryItem(name: "sort", value: "desc")
+	]
+	if keyword.isEmpty == false {
+		queryItems.insert(URLQueryItem(name: "keyword", value: keyword), at: 0)
+	}
+	components?.queryItems = queryItems
+	performAlbireoV2DebugListRequest(label: keyword.isEmpty ? "bangumi" : "search", components: components, completion: completion)
+}
+
+func changeAlbireoV2FavoriteStatus(bangumiID: String,
+								   status: Int,
+								   completion: @escaping (Bool, Any?) -> Void) {
+	guard let favoriteStatus = AlbireoV2FavoriteStatus(legacyValue: status) else {
+		completion(false, "Unsupported Albireo V2 favorite status: \(status)")
+		return
+	}
+
+	let body: [String: Any] = [
+		"bangumiId": bangumiID,
+		"status": favoriteStatus.rawValue,
+		"review": "",
+		"syncToUpstream": true
+	]
+	postAlbireoV2JSON(urlString: "\(currentAlbireoV2APIBaseURL())/favorite", body: body, completion: completion)
+}
+
+func syncAlbireoV2EpisodeWatchProgress(epID: String,
+									   bangumiID: String,
+									   lastWatchPosition: Double,
+									   percentage: Double,
+									   isFinished: Bool,
+									   completion: @escaping (Bool, Any?) -> Void) {
+	let record: [String: Any] = [
+		"bangumiId": bangumiID,
+		"episodeId": epID,
+		"lastWatchPosition": lastWatchPosition,
+		"lastWatchTime": albireoV2CurrentISOString(),
+		"isFinished": isFinished,
+		"percentage": percentage,
+		"version": 2
+	]
+	let body: [String: Any] = [
+		"records": [record]
+	]
+	postAlbireoV2JSON(urlString: "\(currentAlbireoV2APIBaseURL())/episode/watch/sync", body: body, completion: completion)
+}
+
+private func performAlbireoV2DebugListRequest(label: String,
+										components: URLComponents?,
+										completion: @escaping (Bool, Any) -> Void) {
+	guard let urlString = components?.url?.absoluteString else {
+		completion(false, "Failed to build Albireo V2 \(label) URL.")
+		return
+	}
+	print("Albireo V2 \(label) request: \(urlString)")
+	getAlbireoV2JSON(urlString: urlString) { result, data in
+		if let responseData = data as? Data,
+		   let responseText = String(data: responseData, encoding: .utf8) {
+			print("Albireo V2 \(label) response: \(responseText)")
+		} else {
+			print("Albireo V2 \(label) response: \(data)")
+		}
+		completion(result, data)
+	}
+}
+
+private func postAlbireoV2JSON(urlString: String,
+							   body: [String: Any],
+							   completion: @escaping (Bool, Any?) -> Void) {
+	ensureAlbireoV2AccessTokenValid { isTokenReady, tokenResult in
+		guard isTokenReady else {
+			completion(false, tokenResult)
+			return
+		}
+
+		guard let url = URL(string: urlString) else {
+			completion(false, "Invalid Albireo V2 URL: \(urlString)")
+			return
+		}
+
+		do {
+			var request = URLRequest(url: url)
+			request.httpMethod = "POST"
+			request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+			request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+			request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+			request.setValue("en-US,en;q=0.9,ja-JP;q=0.8,ja;q=0.7,zh-CN;q=0.6,zh;q=0.5", forHTTPHeaderField: "Accept-Language")
+			request.setValue(currentAlbireoV2APIServer(), forHTTPHeaderField: "Origin")
+			request.setValue(currentAlbireoV2APIServer(), forHTTPHeaderField: "Referer")
+			request.setValue("Bearer \(albireoV2SettingsHandler.getAlbireoV2AccessToken())", forHTTPHeaderField: "Authorization")
+			request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+
+			print("Albireo V2 POST request: \(urlString), body: \(body)")
+			URLSession.shared.dataTask(with: request) { data, response, error in
+				if let error {
+					completion(false, error.localizedDescription)
+					return
+				}
+
+				if let httpResponse = response as? HTTPURLResponse,
+				   httpResponse.statusCode < 200 || httpResponse.statusCode >= 300 {
+					let responseText = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+					completion(false, "Albireo V2 API HTTP \(httpResponse.statusCode): \(responseText)")
+					return
+				}
+
+				if let data,
+				   let responseText = String(data: data, encoding: .utf8) {
+					completion(true, responseText)
+				} else {
+					completion(true, "success")
+				}
+			}.resume()
+		} catch {
+			completion(false, "Cannot convert Albireo V2 JSON body: \(error.localizedDescription)")
+		}
+	}
+}
+
+private func albireoV2CurrentISOString() -> String {
+	let formatter = ISO8601DateFormatter()
+	formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+	formatter.timeZone = TimeZone(secondsFromGMT: 0)
+	return formatter.string(from: Date())
+}
+
+private func postAlbireoV2TokenRequest(body: [String: String], completion: @escaping (Bool, String) -> Void) {
+	guard let url = URL(string: "\(currentAlbireoV2AuthorizationServer())/oauth2/token") else {
+		completion(false, "Invalid Albireo V2 token endpoint.")
+		return
+	}
+
+	var request = URLRequest(url: url)
+	request.httpMethod = "POST"
+	request.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
+	request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+	request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+	request.httpBody = formURLEncodedData(body)
+
+	URLSession.shared.dataTask(with: request) { data, response, error in
+		if let error {
+			completion(false, error.localizedDescription)
+			return
+		}
+
+		if let httpResponse = response as? HTTPURLResponse,
+		   httpResponse.statusCode < 200 || httpResponse.statusCode >= 300 {
+			let responseText = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+			completion(false, "Albireo V2 token HTTP \(httpResponse.statusCode): \(responseText)")
+			return
+		}
+
+		guard let data else {
+			completion(false, "Albireo V2 token response is empty.")
+			return
+		}
+
+		do {
+			let token = try JSONDecoder().decode(AlbireoV2OAuthTokenResponse.self, from: data)
+			saveAlbireoV2Token(token)
+			completion(true, "Albireo V2 OAuth token saved.")
+		} catch {
+			let responseText = String(data: data, encoding: .utf8) ?? ""
+			completion(false, "Albireo V2 token decode error: \(error.localizedDescription), response: \(responseText)")
+		}
+	}.resume()
+}
+
+private func getAlbireoV2JSON(urlString: String, completion: @escaping (Bool, Any) -> Void) {
+	ensureAlbireoV2AccessTokenValid { isTokenReady, tokenResult in
+		guard isTokenReady else {
+			completion(false, tokenResult)
+			return
+		}
+
+		guard let url = URL(string: urlString) else {
+			completion(false, "Invalid Albireo V2 URL: \(urlString)")
+			return
+		}
+
+		var request = URLRequest(url: url)
+		request.httpMethod = "GET"
+		request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+		request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+		request.setValue("en-US,en;q=0.9,ja-JP;q=0.8,ja;q=0.7,zh-CN;q=0.6,zh;q=0.5", forHTTPHeaderField: "Accept-Language")
+		request.setValue(currentAlbireoV2APIServer(), forHTTPHeaderField: "Origin")
+		request.setValue(currentAlbireoV2APIServer(), forHTTPHeaderField: "Referer")
+		request.setValue("Bearer \(albireoV2SettingsHandler.getAlbireoV2AccessToken())", forHTTPHeaderField: "Authorization")
+
+		URLSession.shared.dataTask(with: request) { data, response, error in
+			if let error {
+				completion(false, error.localizedDescription)
+				return
+			}
+
+			if let httpResponse = response as? HTTPURLResponse,
+			   httpResponse.statusCode < 200 || httpResponse.statusCode >= 300 {
+				let responseText = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+				if httpResponse.statusCode == 401 {
+					printAlbireoV2AccessTokenPayload(label: "Albireo V2 current access token payload after 401", accessToken: albireoV2SettingsHandler.getAlbireoV2AccessToken())
+				}
+				completion(false, "Albireo V2 API HTTP \(httpResponse.statusCode): \(responseText)")
+				return
+			}
+
+			guard let data else {
+				completion(false, "Albireo V2 API response is empty.")
+				return
+			}
+			completion(true, data)
+		}.resume()
+	}
+}
+
+private func saveAlbireoV2Token(_ token: AlbireoV2OAuthTokenResponse) {
+	printAlbireoV2TokenDebugInfo(token)
+	albireoV2SettingsHandler.setAlbireoV2AccessToken(token.accessToken)
+	if let refreshToken = token.refreshToken, !refreshToken.isEmpty {
+		albireoV2SettingsHandler.setAlbireoV2RefreshToken(refreshToken)
+	}
+	if let idToken = token.idToken {
+		albireoV2SettingsHandler.setAlbireoV2IDToken(idToken)
+	}
+	let expireIn = token.expiresIn ?? 3600
+	let expireTime = Int(Date().timeIntervalSince1970) + expireIn
+	albireoV2SettingsHandler.setAlbireoV2ExpireTime(expireTime)
+	albireoV2SettingsHandler.setAlbireoAuthMode(.albireoV2OAuth)
+}
+
+private func printAlbireoV2TokenDebugInfo(_ token: AlbireoV2OAuthTokenResponse) {
+	print("Albireo V2 token scope: \(token.scope ?? "nil")")
+	printAlbireoV2AccessTokenPayload(label: "Albireo V2 access token payload", accessToken: token.accessToken)
+}
+
+private func printAlbireoV2AccessTokenPayload(label: String, accessToken: String) {
+	let parts = accessToken.split(separator: ".")
+	guard parts.count >= 2,
+		  let payloadData = Data(base64URLString: String(parts[1])),
+		  let payload = try? JSONSerialization.jsonObject(with: payloadData) else {
+		print("\(label) is not a readable JWT payload")
+		return
+	}
+	print("\(label): \(payload)")
+}
+
+private func makeAlbireoV2RandomString(length: Int) -> String {
+	let allowed = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
+	return String((0..<length).compactMap { _ in allowed.randomElement() })
+}
+
+private func makeAlbireoV2CodeChallenge(verifier: String) -> String {
+	let digest = SHA256.hash(data: Data(verifier.utf8))
+	return Data(digest).base64URLEncodedString()
+}
+
+private func formURLEncodedData(_ parameters: [String: String]) -> Data {
+	let body = parameters
+		.map { key, value in
+			"\(formURLEscape(key))=\(formURLEscape(value))"
+		}
+		.joined(separator: "&")
+	return Data(body.utf8)
+}
+
+private func formURLEscape(_ string: String) -> String {
+	var allowed = CharacterSet.urlQueryAllowed
+	allowed.remove(charactersIn: ":#[]@!$&'()*+,;=")
+	return string.addingPercentEncoding(withAllowedCharacters: allowed) ?? string
+}
+
+private func normalizedAlbireoV2ServerURL(_ rawValue: String, fallback: String) -> String {
+	var value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+	if value.isEmpty {
+		value = fallback
+	}
+	while value.hasSuffix("/") {
+		value.removeLast()
+	}
+	if !value.contains("://") {
+		value = "https://\(value)"
+	}
+	return value
+}
+
+private extension Data {
+	init?(base64URLString: String) {
+		var value = base64URLString
+			.replacingOccurrences(of: "-", with: "+")
+			.replacingOccurrences(of: "_", with: "/")
+		let padding = value.count % 4
+		if padding > 0 {
+			value.append(String(repeating: "=", count: 4 - padding))
+		}
+		self.init(base64Encoded: value)
+	}
+
+	func base64URLEncodedString() -> String {
+		base64EncodedString()
+			.replacingOccurrences(of: "+", with: "-")
+			.replacingOccurrences(of: "/", with: "_")
+			.replacingOccurrences(of: "=", with: "")
+	}
+}

--- a/moe.TV/Shared/AlbireoV2ServerHandler.swift
+++ b/moe.TV/Shared/AlbireoV2ServerHandler.swift
@@ -16,8 +16,20 @@ private var handledAlbireoV2OAuthCodes = Set<String>()
 private var pendingAlbireoV2OAuthState: String?
 private var pendingAlbireoV2OAuthCodeVerifier: String?
 
+private func currentAlbireoV2ClientID() -> String {
+	albireoV2SettingsHandler.registerSettings()
+	let savedClientID = albireoV2SettingsHandler.getAlbireoV2ClientID().trimmingCharacters(in: .whitespacesAndNewlines)
+	return savedClientID.isEmpty ? albireoV2ClientID : savedClientID
+}
+
+private func currentAlbireoV2RedirectHost() -> String {
+	albireoV2SettingsHandler.registerSettings()
+	let savedHost = albireoV2SettingsHandler.getAlbireoV2RedirectHost().trimmingCharacters(in: .whitespacesAndNewlines)
+	return savedHost.isEmpty ? albireoV2RedirectHost : savedHost
+}
+
 private func currentAlbireoV2RedirectURI() -> String {
-	"moetv://\(albireoV2RedirectHost)"
+	"moetv://\(currentAlbireoV2RedirectHost())"
 }
 
 private func currentAlbireoV2AuthorizationServer() -> String {
@@ -54,8 +66,13 @@ func logoutAlbireoV2() {
 }
 
 func startAlbireoV2Login(completion: @escaping (Bool, String) -> Void) {
-	guard !albireoV2ClientID.isEmpty else {
-		completion(false, "Albireo V2 client id is empty. Please set albireoV2ClientID in DONOTUPLOAD.swift.")
+	let clientID = currentAlbireoV2ClientID()
+	guard !clientID.isEmpty else {
+		completion(false, "Albireo V2 client id is empty.")
+		return
+	}
+	guard !currentAlbireoV2RedirectHost().isEmpty else {
+		completion(false, "Albireo V2 redirect host is empty.")
 		return
 	}
 
@@ -69,7 +86,7 @@ func startAlbireoV2Login(completion: @escaping (Bool, String) -> Void) {
 	let apiServer = currentAlbireoV2APIServer()
 	var components = URLComponents(string: "\(authorizationServer)/oauth2/auth")
 	components?.queryItems = [
-		URLQueryItem(name: "client_id", value: albireoV2ClientID),
+		URLQueryItem(name: "client_id", value: clientID),
 		URLQueryItem(name: "response_type", value: "code"),
 		URLQueryItem(name: "redirect_uri", value: currentAlbireoV2RedirectURI()),
 		URLQueryItem(name: "scope", value: albireoV2Scopes),
@@ -104,7 +121,7 @@ func startAlbireoV2Login(completion: @escaping (Bool, String) -> Void) {
 @discardableResult
 func handleAlbireoV2OAuthCallback(_ url: URL, completion: ((Bool, String) -> Void)? = nil) -> Bool {
 	guard url.scheme == "moetv",
-		  url.host == albireoV2RedirectHost,
+		  url.host == currentAlbireoV2RedirectHost(),
 		  let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
 		  let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
 		  !code.isEmpty else {
@@ -147,7 +164,7 @@ func handleAlbireoV2OAuthCallback(_ url: URL, completion: ((Bool, String) -> Voi
 func getAlbireoV2AccessToken(code: String, codeVerifier: String, completion: @escaping (Bool, String) -> Void) {
 	let body = [
 		"grant_type": "authorization_code",
-		"client_id": albireoV2ClientID,
+		"client_id": currentAlbireoV2ClientID(),
 		"code": code,
 		"redirect_uri": currentAlbireoV2RedirectURI(),
 		"code_verifier": codeVerifier
@@ -170,7 +187,7 @@ func refreshAlbireoV2Token(completion: @escaping (Bool, String) -> Void) {
 
 	let body = [
 		"grant_type": "refresh_token",
-		"client_id": albireoV2ClientID,
+		"client_id": currentAlbireoV2ClientID(),
 		"refresh_token": refreshToken
 	]
 	postAlbireoV2TokenRequest(body: body, completion: completion)

--- a/moe.TV/Shared/BGMTVServerHandler.swift
+++ b/moe.TV/Shared/BGMTVServerHandler.swift
@@ -11,6 +11,8 @@ import SafariServices
 #endif
 private let settingsHandler:SettingsHandler = SettingsHandler()
 private let jsonDecoder = JSONDecoder()
+private let bgmtvOAuthCodeLock = NSLock()
+private var handledBGMTVOAuthCodes = Set<String>()
 
 private let baseBGMTVAPIURL = "https://api.bgm.tv"
 
@@ -136,7 +138,12 @@ private func postServer(urlString:String,
             }
             if let r = response as? HTTPURLResponse{
                 if r.statusCode < 200 || r.statusCode >= 300{
-                    completion(false, "Server HTTP status code \(r.statusCode) error.")
+                    let responseText = (data.flatMap { String(data: $0, encoding: .utf8) } ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                    if responseText.isEmpty {
+                        completion(false, "Server HTTP status code \(r.statusCode) error.")
+                    } else {
+                        completion(false, "Server HTTP status code \(r.statusCode) error: \(responseText)")
+                    }
                     return
                 }
             }
@@ -160,18 +167,7 @@ func startBGMTVLogin() {
         switch result {
         case .success(let callbackURL):
             print("OAuth callback URL: \(callbackURL.absoluteString)")
-
-            if let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
-               let code = components.queryItems?.first(where: { $0.name == "code" })?.value {
-                print("OAuth code: \(code)")
-                getBGMTVAccessToken(code: code) { isSuccess, result in
-                    if isSuccess {
-                        NotificationCenter.default.post(name: Notification.Name("getBGMUserInfo"), object: nil)
-                    } else {
-                        print("getBGMTVAccessToken failed: \(result)")
-                    }
-                }
-            } else {
+            if !handleBGMTVOAuthCallback(callbackURL) {
                 print("OAuth callback missing code: \(callbackURL.absoluteString)")
             }
 
@@ -180,6 +176,35 @@ func startBGMTVLogin() {
         }
     }
 #endif
+}
+
+@discardableResult
+func handleBGMTVOAuthCallback(_ url: URL) -> Bool {
+    guard url.host == "bgmtv",
+          let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let code = components.queryItems?.first(where: { $0.name == "code" })?.value,
+          !code.isEmpty else {
+        return false
+    }
+
+    bgmtvOAuthCodeLock.lock()
+    let isNewCode = handledBGMTVOAuthCodes.insert(code).inserted
+    bgmtvOAuthCodeLock.unlock()
+
+    guard isNewCode else {
+        print("Ignoring duplicate bgm.tv OAuth code callback")
+        return true
+    }
+
+    print("OAuth code: \(code)")
+    getBGMTVAccessToken(code: code) { isSuccess, result in
+        if isSuccess {
+            NotificationCenter.default.post(name: Notification.Name("getBGMUserInfo"), object: nil)
+        } else {
+            print("getBGMTVAccessToken failed: \(result)")
+        }
+    }
+    return true
 }
 
 func getBGMTVAccessToken(code:String, completion:@escaping (Bool, String) -> Void){
@@ -198,7 +223,12 @@ func getBGMTVAccessToken(code:String, completion:@escaping (Bool, String) -> Voi
     ) { result, data in
         if result{
             do{
-                if let r = try jsonDecoder.decode(BGMTVOauthAccessTokenModel?.self, from: data as! Data){
+                guard let responseData = data as? Data else {
+                    completion(false, "get bgm.tv access token error: response data is empty")
+                    return
+                }
+
+                if let r = try jsonDecoder.decode(BGMTVOauthAccessTokenModel?.self, from: responseData){
                     if let accesstoken = r.access_token,
                        let refreshToken = r.refresh_token,
                        let expiresIn = r.expires_in {
@@ -214,10 +244,11 @@ func getBGMTVAccessToken(code:String, completion:@escaping (Bool, String) -> Voi
                     completion(false, "json decode error -1")
                 }
             }catch{
-                completion(false, "json decode error")
+                let responseText = (data as? Data).flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                completion(false, "json decode error: \(error.localizedDescription), response: \(responseText)")
             }
         }else{
-            completion(false, "get bgm.tv access token error")
+            completion(false, "get bgm.tv access token error: \(data)")
         }
     }
 }

--- a/moe.TV/Shared/OfflinePlaybackManager.swift
+++ b/moe.TV/Shared/OfflinePlaybackManager.swift
@@ -17,6 +17,8 @@ struct OfflineVideoItem: Codable{
     var episodeName:String? = nil
 }
 class OfflinePlaybackManager: ObservableObject {
+    private var cachedStatusList: [OfflineVideoItem]?
+
     // MARK: - Playback manager
 //    func isPlayBackStatsExisit(filename:String) -> Bool{
 //        if let list = getSaveStatusList(){
@@ -29,7 +31,6 @@ class OfflinePlaybackManager: ObservableObject {
     
     func getPlayBackStatus(filename:String) -> OfflineVideoItem?{
         if let list = getSaveStatusList(){
-            print(list)
             if let item = list.first(where: {$0.filename == filename}) {
                 return item
             }
@@ -54,7 +55,6 @@ class OfflinePlaybackManager: ObservableObject {
     
     func setPlayBackStatus(item:OfflineVideoItem){
         if let oldItem = getPlayBackStatus(filename: item.filename){
-            print("found oldItem:\(oldItem)")
             deletePlayBackStatus(filename: oldItem.filename)
             addPlayBackStatus(
                 item: OfflineVideoItem(
@@ -73,7 +73,6 @@ class OfflinePlaybackManager: ObservableObject {
         addPlayBackStatus(item: item)
     }
     func addPlayBackStatus(item:OfflineVideoItem){
-        print("add:\(item)")
         if var list = getSaveStatusList(){
             list.append(item)
             self.setSaveStatusList(array: list)
@@ -95,6 +94,9 @@ class OfflinePlaybackManager: ObservableObject {
     private let kOfflinePlaybackStatus = "offlinePlaybackStatus"
     
     private func getSaveStatusList() -> [OfflineVideoItem]?{
+        if let cachedStatusList {
+            return cachedStatusList.isEmpty ? nil : cachedStatusList
+        }
         let arr = settingsHandler.readArrayFromPList(key: kOfflinePlaybackStatus)
         var decodeArr = [OfflineVideoItem]()
         arr?.forEach({ item in
@@ -103,7 +105,7 @@ class OfflinePlaybackManager: ObservableObject {
                 decodeArr.append(decodeData)
                     }
         })
-        print("read(\(decodeArr.count))items:\(decodeArr)")
+        cachedStatusList = decodeArr
         if decodeArr.isEmpty{
             return nil
         }
@@ -111,7 +113,7 @@ class OfflinePlaybackManager: ObservableObject {
     }
     
     private func setSaveStatusList(array:[OfflineVideoItem]){
-        print(array)
+        cachedStatusList = array
         
         var encodeArr = [Any]()
         array.forEach { item in
@@ -119,7 +121,6 @@ class OfflinePlaybackManager: ObservableObject {
                 encodeArr.append(encoded)
             }
         }
-        print("saved(\(encodeArr.count))items:\(encodeArr)")
         settingsHandler.saveToPList(key: kOfflinePlaybackStatus, data: encodeArr)
         
     }

--- a/moe.TV/Shared/SettingsHandler.swift
+++ b/moe.TV/Shared/SettingsHandler.swift
@@ -6,6 +6,12 @@
 //
 
 import Foundation
+
+enum AlbireoAuthMode: String {
+	case legacyCookie
+	case albireoV2OAuth
+}
+
 class SettingsHandler {
 	// MARK: - Keys
     private let UD_SUITE_NAME = "group.moetv"
@@ -14,6 +20,13 @@ class SettingsHandler {
     private let kBGMTVAccessToken = "kBGMTVAccessToken"
     private let kBGMTVRefreshToken = "kBGMTVRefreshToken"
     private let kBGMTVExpireTime = "kBGMTVExpireTime"
+	private let kAlbireoAuthMode = "kAlbireoAuthMode"
+	private let kAlbireoV2AccessToken = "kAlbireoV2AccessToken"
+	private let kAlbireoV2RefreshToken = "kAlbireoV2RefreshToken"
+	private let kAlbireoV2IDToken = "kAlbireoV2IDToken"
+	private let kAlbireoV2ExpireTime = "kAlbireoV2ExpireTime"
+	private let kAlbireoV2AuthorizationServerURL = "kAlbireoV2AuthorizationServerURL"
+	private let kAlbireoV2APIServerURL = "kAlbireoV2APIServerURL"
 
 	private let kLandscapePlayback = "kLandscapePlayback"
 	private let kShowBgmtvWebWhilePlaying = "kShowBgmtvWebWhilePlaying"
@@ -69,6 +82,68 @@ class SettingsHandler {
     func getAlbireoServerAddr() -> String {
         return ub.string(forKey: kServerAddr) ?? ""
     }
+
+	// MARK: - Albireo auth mode
+	func setAlbireoAuthMode(_ mode: AlbireoAuthMode) {
+		ub.set(mode.rawValue, forKey: kAlbireoAuthMode)
+		sync()
+	}
+	func getAlbireoAuthMode() -> AlbireoAuthMode {
+		AlbireoAuthMode(rawValue: ub.string(forKey: kAlbireoAuthMode) ?? "") ?? .legacyCookie
+	}
+
+	// MARK: - Albireo V2
+	func setAlbireoV2AccessToken(_ token: String) {
+		ub.set(token, forKey: kAlbireoV2AccessToken)
+		sync()
+	}
+	func getAlbireoV2AccessToken() -> String {
+		return ub.string(forKey: kAlbireoV2AccessToken) ?? ""
+	}
+	func setAlbireoV2RefreshToken(_ token: String) {
+		ub.set(token, forKey: kAlbireoV2RefreshToken)
+		sync()
+	}
+	func getAlbireoV2RefreshToken() -> String {
+		return ub.string(forKey: kAlbireoV2RefreshToken) ?? ""
+	}
+	func setAlbireoV2IDToken(_ token: String) {
+		ub.set(token, forKey: kAlbireoV2IDToken)
+		sync()
+	}
+	func getAlbireoV2IDToken() -> String {
+		return ub.string(forKey: kAlbireoV2IDToken) ?? ""
+	}
+	func setAlbireoV2ExpireTime(_ time: Int) {
+		ub.set(Int64(time), forKey: kAlbireoV2ExpireTime)
+		sync()
+	}
+	func getAlbireoV2ExpireTime() -> Int {
+		return Int(ub.longLong(forKey: kAlbireoV2ExpireTime))
+	}
+	func clearAlbireoV2AuthInfo() {
+		setAlbireoV2AccessToken("")
+		setAlbireoV2RefreshToken("")
+		setAlbireoV2IDToken("")
+		setAlbireoV2ExpireTime(0)
+		if getAlbireoAuthMode() == .albireoV2OAuth {
+			setAlbireoAuthMode(.legacyCookie)
+		}
+	}
+	func setAlbireoV2AuthorizationServerURL(_ url: String) {
+		ub.set(url, forKey: kAlbireoV2AuthorizationServerURL)
+		sync()
+	}
+	func getAlbireoV2AuthorizationServerURL() -> String {
+		return ub.string(forKey: kAlbireoV2AuthorizationServerURL) ?? ""
+	}
+	func setAlbireoV2APIServerURL(_ url: String) {
+		ub.set(url, forKey: kAlbireoV2APIServerURL)
+		sync()
+	}
+	func getAlbireoV2APIServerURL() -> String {
+		return ub.string(forKey: kAlbireoV2APIServerURL) ?? ""
+	}
 
 	//BGMTV Username
 	func setBGMTVUsername(username: String){
@@ -230,7 +305,6 @@ class SettingsHandler {
     // MARK: - Plist handler
     func saveToPList(key:String, data:Any) {
         if let path = getSaveFilePath(key: key){
-            print("savekeyPath:\(path)")
             do{
                 let data = try PropertyListSerialization.data(fromPropertyList: data, format: .xml, options: 0)
                 try data.write(to: path)
@@ -241,7 +315,6 @@ class SettingsHandler {
     }
     func readArrayFromPList(key:String) -> [Any]? {
         if let path = getSaveFilePath(key: key){
-            print("readkeyPath:\(path)")
             guard let plistData = FileManager.default.contents(atPath: path.path) else { return nil }
             guard let plist = try? PropertyListSerialization.propertyList(from: plistData, options: .mutableContainers, format:nil) as? [Any] else { return nil }
             //print(plist)

--- a/moe.TV/Shared/SettingsHandler.swift
+++ b/moe.TV/Shared/SettingsHandler.swift
@@ -27,6 +27,8 @@ class SettingsHandler {
 	private let kAlbireoV2ExpireTime = "kAlbireoV2ExpireTime"
 	private let kAlbireoV2AuthorizationServerURL = "kAlbireoV2AuthorizationServerURL"
 	private let kAlbireoV2APIServerURL = "kAlbireoV2APIServerURL"
+	private let kAlbireoV2ClientID = "kAlbireoV2ClientID"
+	private let kAlbireoV2RedirectHost = "kAlbireoV2RedirectHost"
 
 	private let kLandscapePlayback = "kLandscapePlayback"
 	private let kShowBgmtvWebWhilePlaying = "kShowBgmtvWebWhilePlaying"
@@ -143,6 +145,20 @@ class SettingsHandler {
 	}
 	func getAlbireoV2APIServerURL() -> String {
 		return ub.string(forKey: kAlbireoV2APIServerURL) ?? ""
+	}
+	func setAlbireoV2ClientID(_ clientID: String) {
+		ub.set(clientID, forKey: kAlbireoV2ClientID)
+		sync()
+	}
+	func getAlbireoV2ClientID() -> String {
+		return ub.string(forKey: kAlbireoV2ClientID) ?? ""
+	}
+	func setAlbireoV2RedirectHost(_ host: String) {
+		ub.set(host, forKey: kAlbireoV2RedirectHost)
+		sync()
+	}
+	func getAlbireoV2RedirectHost() -> String {
+		return ub.string(forKey: kAlbireoV2RedirectHost) ?? ""
 	}
 
 	//BGMTV Username

--- a/moe.TV/Support Files/Localizable.xcstrings
+++ b/moe.TV/Support Files/Localizable.xcstrings
@@ -14,6 +14,24 @@
             "state" : "new",
             "value" : "%1$@ / %2$@"
           }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$@"
+          }
         }
       }
     },
@@ -88,10 +106,35 @@
       }
     },
     "AccessToken" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクセストークン"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "访问令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存取權杖"
+          }
+        }
+      }
     },
     "Active Downloads" : {
       "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード中"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -175,6 +218,9 @@
         }
       }
     },
+    "Albireo V2" : {
+      "shouldTranslate" : false
+    },
     "All video download failed." : {
       "localizations" : {
         "ja" : {
@@ -244,6 +290,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已下載，如果想覆蓋文件，請在下載管理裡刪除舊影片"
+          }
+        }
+      }
+    },
+    "API Server URL" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APIサーバーURL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API服务器地址"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API伺服器地址"
           }
         }
       }
@@ -336,6 +404,28 @@
         }
       }
     },
+    "Authorization Server URL" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認証サーバーURL"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授权服务器地址"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權伺服器地址"
+          }
+        }
+      }
+    },
     "Back 15 seconds" : {
       "localizations" : {
         "ja" : {
@@ -358,48 +448,11 @@
         }
       }
     },
-    "Backward 15 seconds" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "15秒戻し"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回退15秒"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快退15秒"
-          }
-        }
-      }
-    },
     "Bgm.tv" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bgm.tv"
-          }
-        }
-      }
+      "shouldTranslate" : false
     },
     "BGM.TV" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BGM.TV"
-          }
-        }
-      }
+      "shouldTranslate" : false
     },
     "Bgm.tv favorite status has changed" : {
       "localizations" : {
@@ -446,7 +499,26 @@
       }
     },
     "BGM.TV Logined" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BGM.TV ログイン済み"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BGM.TV 已登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BGM.TV 已登入"
+          }
+        }
+      }
     },
     "Bgm.tv setting on tvOS is not supported. But you can use iOS or macOS device to setup and will do sync with bgm.tv on tvOS." : {
       "localizations" : {
@@ -493,7 +565,26 @@
       }
     },
     "Cache" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快取"
+          }
+        }
+      }
     },
     "Cancel" : {
       "localizations" : {
@@ -513,6 +604,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消"
+          }
+        }
+      }
+    },
+    "Cancel download" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードをキャンセル"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消下載"
           }
         }
       }
@@ -583,8 +696,36 @@
         }
       }
     },
+    "Choose a sign-in method" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン方法を選択"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择登录方式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇登入方式"
+          }
+        }
+      }
+    },
     "Clear history" : {
       "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "履歴を削除"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -644,7 +785,26 @@
       }
     },
     "Clear streaming video cache" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストリーミング動画キャッシュを削除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清理流媒体视频缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清理串流影片快取"
+          }
+        }
+      }
     },
     "Close" : {
       "localizations" : {
@@ -735,7 +895,26 @@
       }
     },
     "Copy current frame" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のフレームをコピー"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制当前画面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製目前畫面"
+          }
+        }
+      }
     },
     "Custom status" : {
       "localizations" : {
@@ -760,10 +939,48 @@
       }
     },
     "Debug" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバッグ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "调试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "除錯"
+          }
+        }
+      }
     },
     "Debug menu" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デバッグメニュー"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "调试菜单"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "除錯選單"
+          }
+        }
+      }
     },
     "Default playbck speed" : {
       "localizations" : {
@@ -805,6 +1022,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除"
+          }
+        }
+      }
+    },
+    "Delete selected videos" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択した動画を削除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除选中的视频"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除選取的影片"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
@@ -942,7 +1203,26 @@
       }
     },
     "ExpireTime" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "过期时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過期時間"
+          }
+        }
+      }
     },
     "Favorite status conflict has been detected. Choose which one you want to keep." : {
       "localizations" : {
@@ -1124,13 +1404,51 @@
       "shouldTranslate" : false
     },
     "iCloud Available" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 利用可能"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud 可用"
+          }
+        }
+      }
     },
     "ID: %@" : {
       "shouldTranslate" : false
     },
     "Later" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あとで"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "稍后"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "稍後"
+          }
+        }
+      }
     },
     "Loading..." : {
       "localizations" : {
@@ -1155,7 +1473,26 @@
       }
     },
     "Log Out" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログアウト"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登出"
+          }
+        }
+      }
     },
     "Login" : {
       "localizations" : {
@@ -1175,6 +1512,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入"
+          }
+        }
+      }
+    },
+    "Login method" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン方法"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录方式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入方式"
+          }
+        }
+      }
+    },
+    "Login with OAuth2" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth2でログイン"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 OAuth2 登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 OAuth2 登入"
           }
         }
       }
@@ -1545,29 +1926,6 @@
         }
       }
     },
-    "Play/Pause" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再生/一時停止"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "播放/暂停"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "播放/暫停"
-          }
-        }
-      }
-    },
     "Playback History" : {
       "localizations" : {
         "ja" : {
@@ -1679,19 +2037,114 @@
       }
     },
     "Re-login" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再ログイン"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新登入"
+          }
+        }
+      }
     },
     "Re-Sync with iCloud" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud と再同期"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新同步 iCloud"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新同步 iCloud"
+          }
+        }
+      }
     },
     "Refresh BGM Access Token" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BGM アクセストークンを更新"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新 BGM 访问令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理 BGM 存取權杖"
+          }
+        }
+      }
     },
     "Refresh video cache size" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画キャッシュサイズを更新"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新视频缓存大小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理影片快取大小"
+          }
+        }
+      }
     },
     "RefreshToken" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リフレッシュトークン"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新令牌"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理權杖"
+          }
+        }
+      }
     },
     "Search" : {
       "extractionState" : "manual",
@@ -1756,6 +2209,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢索..."
+          }
+        }
+      }
+    },
+    "Select" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇"
           }
         }
       }
@@ -2061,7 +2536,26 @@
       }
     },
     "Streaming video cache" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストリーミング動画キャッシュ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "流媒体视频缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "串流影片快取"
+          }
+        }
+      }
     },
     "Sync status with bgm.tv" : {
       "localizations" : {
@@ -2219,7 +2713,26 @@
       "shouldTranslate" : false
     },
     "Volume %@" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量 %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量 %@"
+          }
+        }
+      }
     },
     "Watched" : {
       "localizations" : {
@@ -2288,7 +2801,26 @@
       }
     },
     "Yes" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "はい"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/moe.TV/Support Files/Localizable.xcstrings
+++ b/moe.TV/Support Files/Localizable.xcstrings
@@ -1560,6 +1560,50 @@
         }
       }
     },
+    "OAuth2 Client ID" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth2 クライアントID"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth2 客户端 ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth2 用戶端 ID"
+          }
+        }
+      }
+    },
+    "OAuth2 Redirect Host" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth2 リダイレクトホスト"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth2 回调 Host"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth2 回呼 Host"
+          }
+        }
+      }
+    },
     "Logout" : {
       "localizations" : {
         "ja" : {

--- a/moe.TV/Views/BGMDetail/EPCellView.swift
+++ b/moe.TV/Views/BGMDetail/EPCellView.swift
@@ -234,19 +234,15 @@ struct EPCellView: View {
     }
 
     private func resolveLocalDownloadIfNeeded() {
-        guard localOfflineItem == nil else { return }
-        getAlbireoEPDetail(ep_id: newEPItem.ep.id) { result, data in
-            guard result,
-                  let epDetail = data as? EpisodeDetailModel,
-                  let request = downloadManager.makeDownloadRequest(epDetail: epDetail),
-                  downloadManager.getVideoFileAsset(filename: request.filename) != nil else {
-                return
-            }
-            DispatchQueue.main.async {
-                self.saveOfflineItem(epDetail: epDetail, request: request)
-                self.resolvedLocalOfflineItem = self.offlinePBM.getPlayBackStatus(filename: request.filename)
-            }
-        }
+		if let item = offlinePBM.getPlayBackStatus(epID: newEPItem.ep.id),
+		   downloadManager.getVideoFileAsset(filename: item.filename) != nil {
+			resolvedLocalOfflineItem = item
+			return
+		}
+		if let item = offlinePBM.getPlayBackStatus(bgmEpsID: newEPItem.ep.bgm_eps_id),
+		   downloadManager.getVideoFileAsset(filename: item.filename) != nil {
+			resolvedLocalOfflineItem = item
+		}
     }
 
     private func saveOfflineItem(epDetail: EpisodeDetailModel, request: DownloadRequest) {

--- a/moe.TV/Views/BGMMaster/BangumiListView.swift
+++ b/moe.TV/Views/BGMMaster/BangumiListView.swift
@@ -22,11 +22,23 @@ struct BangumiListView: View {
         if listVC.isLoading{
             ProgressView()
         }
-		List(listVC.bangumiFiltered, id: \.self, selection: $selectedItem){ item in
+		List(selection: $selectedItem) {
+			ForEach(listVC.bangumiFiltered, id: \.self) { item in
                 NavigationLink(value: item) {
                     BangumiCellView(bangumiItem: item)
                 }
+				.onAppear {
+					listVC.loadNextPageIfNeeded(currentItem: item)
+				}
+			}
+			if listVC.isLoadingNextPage {
+				HStack {
+					Spacer()
+					ProgressView()
+					Spacer()
+				}
             }
+		}
             .refreshable {
                 print("refreshable.getBGMList")
                 getBGMList()

--- a/moe.TV/Views/DebugView.swift
+++ b/moe.TV/Views/DebugView.swift
@@ -38,6 +38,16 @@ struct DebugView: View {
                         Text(string)
                     }
                 }
+
+				Section(header: Text("Albireo V2")) {
+					debugRow(title: "Auth mode", value: debugVC.getAlbireoAuthModeDEBUG())
+					debugRow(title: "Authorization server", value: debugVC.getAlbireoV2AuthorizationServerURLDEBUG())
+					debugRow(title: "API server", value: debugVC.getAlbireoV2APIServerURLDEBUG())
+					debugRow(title: "AccessToken", value: debugVC.getAlbireoV2AccessTokenDEBUG())
+					debugRow(title: "RefreshToken", value: debugVC.getAlbireoV2RefreshTokenDEBUG())
+					debugRow(title: "IDToken", value: debugVC.getAlbireoV2IDTokenDEBUG())
+					debugRow(title: "ExpireTime", value: "\(debugVC.getAlbireoV2ExpireTimeDEBUG())")
+				}
                 
                 Section(header: Text("BGM.TV") ) {
                     Toggle("BGM.TV Logined", isOn:$syncWithBGMTV )
@@ -123,5 +133,17 @@ struct DebugView: View {
 
 	private func formatByteCount(_ byteCount: Int64) -> String {
 		ByteCountFormatter.string(fromByteCount: byteCount, countStyle: .file)
+	}
+
+	@ViewBuilder
+	private func debugRow(title: String, value: String) -> some View {
+		VStack(alignment: .leading, spacing: 6) {
+			Text(title)
+				.font(.caption)
+				.foregroundStyle(.secondary)
+			Text(value.isEmpty ? "(empty)" : value)
+				.font(.caption)
+				.textSelection(.enabled)
+		}
 	}
 }

--- a/moe.TV/Views/DownloadListView.swift
+++ b/moe.TV/Views/DownloadListView.swift
@@ -64,13 +64,19 @@ struct DownloadListView: View {
 #if os(iOS)
             if !dlListVC.fileList.isEmpty {
                 ToolbarItemGroup(placement: .automatic) {
-                    EditButton()
+                    Button {
+                        editMode = editMode.isEditing ? .inactive : .active
+                    } label: {
+                        Image(systemName: editMode.isEditing ? "checkmark.circle" : "checklist")
+                    }
+                    .accessibilityLabel(editMode.isEditing ? "Done" : "Select")
                     if editMode.isEditing {
                         Button(role: .destructive) {
                             deleteSelectedFiles()
                         } label: {
-                            Label("Delete", systemImage: "trash")
+                            Image(systemName: "trash")
                         }
+                        .accessibilityLabel("Delete selected videos")
                         .disabled(selectedFiles.isEmpty)
                     }
                 }
@@ -163,16 +169,20 @@ struct DownloadListView: View {
             Button {
                 playDownloadedVideo(fileURL)
             } label: {
-                Image(systemName: "play.circle")
+                Image(systemName: "play.circle.fill")
+                    .font(.title3)
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel("Play")
 #if os(tvOS)
 			Button(role: .destructive) {
 				deleteFiles([fileURL])
 			} label: {
-				Image(systemName: "trash")
+				Image(systemName: "trash.fill")
+                    .font(.title3)
 			}
 			.buttonStyle(.borderless)
+            .accessibilityLabel("Delete")
 #endif
         }
         .contentShape(Rectangle())
@@ -203,9 +213,11 @@ struct DownloadListView: View {
                 Button(role: .destructive) {
                     downloadManager.cancelDownload(filename: item.filename)
                 } label: {
-                    Image(systemName: "xmark.circle")
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title3)
                 }
                 .buttonStyle(.borderless)
+                .accessibilityLabel("Cancel download")
             }
 
             ProgressView(value: item.progress)

--- a/moe.TV/Views/LoginView.swift
+++ b/moe.TV/Views/LoginView.swift
@@ -130,6 +130,10 @@ struct LoginView: View {
 #if os(iOS)
 				.keyboardType(.URL)
 #endif
+			TextField("OAuth2 Client ID", text: $loginVC.albireoV2OAuthClientID)
+				.loginTextFieldStyle()
+			TextField("OAuth2 Redirect Host", text: $loginVC.albireoV2OAuthRedirectHost)
+				.loginTextFieldStyle()
 			Button(action: {
 				loginVC.loginWithAlbireoV2()
 			}, label: {
@@ -137,7 +141,12 @@ struct LoginView: View {
 					.frame(maxWidth: .infinity)
 			})
 			.buttonStyle(.borderedProminent)
-			.disabled(!loginVC.isValidAlbireoV2AuthorizationServer || !loginVC.isValidAlbireoV2APIServer)
+			.disabled(
+				!loginVC.isValidAlbireoV2AuthorizationServer ||
+				!loginVC.isValidAlbireoV2APIServer ||
+				!loginVC.isValidAlbireoV2ClientID ||
+				!loginVC.isValidAlbireoV2RedirectHost
+			)
 		}
 #endif
 	}

--- a/moe.TV/Views/LoginView.swift
+++ b/moe.TV/Views/LoginView.swift
@@ -7,82 +7,151 @@
 
 import SwiftUI
 
+private enum LoginMethod: String, CaseIterable, Identifiable {
+	case password
+	case oauth2
+
+	var id: String { rawValue }
+
+	var title: String {
+		switch self {
+		case .password:
+			return "Password"
+		case .oauth2:
+			return "OAuth2"
+		}
+	}
+}
+
 struct LoginView: View {
 	@ObservedObject var loginVC: LoginViewController
 //	@Binding var selectedItem: BangumiItemModel?
 //	@Binding var navigationPath:[AnyHashable]
 	
 	@State private var selectedFunc: FuncViewModel? = nil
+	@State private var loginMethod: LoginMethod = .oauth2
 	
 
     var body: some View {
-        if loadAlbireoCookies() || loginVC.isLoginSuccessd{
+        if isAlbireoAuthenticated() || loginVC.isLoginSuccessd{
 			MainListView(selectedFunc: $selectedFunc, loginVC: loginVC)
         }else{
-            HStack{
-                Spacer()
-                    
-                VStack{
-                    Spacer()
-                    Text("Connect to Albireo Services")
-                        .lineLimit(2)
-                        .fontWeight(.bold)
-                        .font(.title)
-                        .padding(50)
-                    
-                    Spacer()
-                    
-                    TextField("Server URL", text: $loginVC.server)
-#if !os(macOS)
-                        .textInputAutocapitalization(.never)
-#endif
-#if os(iOS)
-                        .keyboardType(.URL)
-#endif
-                        .autocorrectionDisabled()
-                        .padding(10)
-                    TextField("Username", text: $loginVC.username)
-#if !os(macOS)
-                        .textInputAutocapitalization(.never)
-#endif
-                        .autocorrectionDisabled()
-                        .padding(10)
-                    SecureField("Password", text: $loginVC.password)
-#if !os(macOS)
-                        .textInputAutocapitalization(.never)
-#endif
-                        .autocorrectionDisabled()
-                        .padding(10)
-						.onSubmit {
-							loginVC.isLoginButtonTapped = true
+			ScrollView {
+				VStack(spacing: 24) {
+					Spacer(minLength: 40)
+
+					VStack(spacing: 8) {
+						Text("Connect to Albireo Services")
+							.lineLimit(2)
+							.fontWeight(.bold)
+							.font(.title)
+						Text("Choose a sign-in method")
+							.font(.subheadline)
+							.foregroundColor(.secondary)
+					}
+
+					VStack(spacing: 16) {
+						Picker("Login method", selection: $loginMethod) {
+							ForEach(LoginMethod.allCases) { method in
+								Text(method.title).tag(method)
+							}
 						}
-                    Spacer()
-                    Button(action: {
-                        loginVC.isLoginButtonTapped = true
-                        
-                    }, label: {
-                        Text("Login")
-                            .foregroundColor(.white)
-                    })
-                    .padding(10)
-                    .background(loginVC.isValidUsername && loginVC.isValidPassword && loginVC.isValidServer ? Color.blue : Color.gray)
-                    .cornerRadius(10, antialiased: true)
-                    .disabled(!loginVC.isValidUsername || !loginVC.isValidPassword || !loginVC.isValidServer)
-					
-					.alert(
-						loginVC.errorMessage,
-						isPresented: $loginVC.showError
-					) {
-                        Button("OK", role: .cancel) { }
-                    }
-                    Spacer()
-                    
-                    OfflineView().padding(10)
-                }
-                Spacer()
-            }
+						.pickerStyle(.segmented)
+
+						switch loginMethod {
+						case .password:
+							passwordLoginFields
+						case .oauth2:
+							oauth2LoginFields
+						}
+					}
+					.padding(20)
+					.frame(maxWidth: 520)
+#if !os(tvOS)
+					.background(.regularMaterial)
+					.clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+#endif
+
+					OfflineView().padding(10)
+					Spacer(minLength: 40)
+				}
+				.frame(maxWidth: .infinity)
+				.padding()
+				.alert(
+					loginVC.errorMessage,
+					isPresented: $loginVC.showError
+				) {
+					Button("OK", role: .cancel) { }
+				}
+			}
         }
     }
+
+	private var passwordLoginFields: some View {
+		VStack(spacing: 12) {
+			TextField("Server URL", text: $loginVC.server)
+				.loginTextFieldStyle()
+#if os(iOS)
+				.keyboardType(.URL)
+#endif
+			TextField("Username", text: $loginVC.username)
+				.loginTextFieldStyle()
+			SecureField("Password", text: $loginVC.password)
+				.loginTextFieldStyle()
+				.onSubmit {
+					loginVC.isLoginButtonTapped = true
+				}
+			Button(action: {
+				loginVC.isLoginButtonTapped = true
+			}, label: {
+				Label("Login", systemImage: "person.crop.circle.badge.checkmark")
+					.frame(maxWidth: .infinity)
+			})
+			.buttonStyle(.borderedProminent)
+			.disabled(!loginVC.isValidUsername || !loginVC.isValidPassword || !loginVC.isValidServer)
+		}
+	}
+
+	@ViewBuilder
+	private var oauth2LoginFields: some View {
+#if os(tvOS)
+		Text("Albireo OAuth2 login is not available on tvOS. Please log in on another device and enable iCloud sync.")
+			.multilineTextAlignment(.center)
+			.padding(10)
+#else
+		VStack(spacing: 12) {
+			TextField("Authorization Server URL", text: $loginVC.albireoV2AuthorizationServer)
+				.loginTextFieldStyle()
+#if os(iOS)
+				.keyboardType(.URL)
+#endif
+			TextField("API Server URL", text: $loginVC.albireoV2APIServer)
+				.loginTextFieldStyle()
+#if os(iOS)
+				.keyboardType(.URL)
+#endif
+			Button(action: {
+				loginVC.loginWithAlbireoV2()
+			}, label: {
+				Label("Login with OAuth2", systemImage: "key.fill")
+					.frame(maxWidth: .infinity)
+			})
+			.buttonStyle(.borderedProminent)
+			.disabled(!loginVC.isValidAlbireoV2AuthorizationServer || !loginVC.isValidAlbireoV2APIServer)
+		}
+#endif
+	}
+}
+
+private extension View {
+	func loginTextFieldStyle() -> some View {
+		self
+#if !os(macOS)
+			.textInputAutocapitalization(.never)
+#endif
+			.autocorrectionDisabled()
+			.textFieldStyle(.roundedBorder)
+	}
 }
 
 //struct LoginView_Previews: PreviewProvider {

--- a/moe.TV/Views/MainListView.swift
+++ b/moe.TV/Views/MainListView.swift
@@ -324,7 +324,7 @@ private final class StartupLoginValidator: ObservableObject {
 	}
 
 	private func validateAlbireoLogin() {
-		guard loadAlbireoCookies() else { return }
+		guard isAlbireoAuthenticated() else { return }
 		isAlbireoLoginValid { [weak self] isValid in
 			guard !isValid else { return }
 			Task { @MainActor in

--- a/moe.TV/Views/OfflineView.swift
+++ b/moe.TV/Views/OfflineView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct OfflineView: View {
+    @EnvironmentObject var downloadManager: DownloadManager
+    @EnvironmentObject var offlinePBM: OfflinePlaybackManager
     @State private var showDownloadList = false
     
     var body: some View {
@@ -27,9 +29,10 @@ struct OfflineView: View {
                 }).padding(20)
                 Spacer()
 #endif
-            }
+			}
 			DownloadListView( dlListVC: DownloadListViewController())
-                .environmentObject(OfflinePlaybackManager())
+                .environmentObject(downloadManager)
+                .environmentObject(offlinePBM)
         })
     }
 }

--- a/moe.TV/Views/SettingsView.swift
+++ b/moe.TV/Views/SettingsView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @EnvironmentObject var downloadManager: DownloadManager
+    @EnvironmentObject var offlinePBM: OfflinePlaybackManager
 //    @State private var syncWithBGMTV = isBGMTVlogined()
     @State private var showDownloadList: Bool = false
 	@State private var landscapePlayback: Bool = false
@@ -237,7 +239,8 @@ struct SettingsView: View {
                                         onPlayDownloadedVideo?(url, filename, position)
                                     }
 								)
-								.environmentObject(OfflinePlaybackManager())
+								.environmentObject(downloadManager)
+								.environmentObject(offlinePBM)
 							})
 					}
 

--- a/moe.TV/moe_TVApp.swift
+++ b/moe.TV/moe_TVApp.swift
@@ -16,6 +16,7 @@ struct moe_TVApp: App {
 //    @State var bgmID:String?
     @StateObject var networkMonitor = NetworkMonitor()
 	@StateObject var downloadManager = DownloadManager()
+	@StateObject var offlinePlaybackManager = OfflinePlaybackManager()
 //	@State var selectedItem: BangumiItemModel?
 	@State private var navigationPath: [String] = []
 
@@ -39,10 +40,12 @@ struct moe_TVApp: App {
 			})
 			.environmentObject(networkMonitor)
 			.environmentObject(downloadManager)
+			.environmentObject(offlinePlaybackManager)
 #else
 			MainView()
 				.environmentObject(networkMonitor)
 				.environmentObject(downloadManager)
+				.environmentObject(offlinePlaybackManager)
 				.handlesExternalEvents(preferring: ["*"], allowing: ["*"])
 #endif
 
@@ -96,6 +99,12 @@ struct moe_TVApp: App {
 			Spacer()
                 .onOpenURL { url in
                     print(url.absoluteURL)
+                    if handleAlbireoV2OAuthCallback(url) {
+                        return
+                    }
+                    if handleBGMTVOAuthCallback(url) {
+                        return
+                    }
                     if let queryUrlComponents = URLComponents(string: url.absoluteString){
                         switch url.host{
                         case "detail":
@@ -104,19 +113,6 @@ struct moe_TVApp: App {
 //                                self.bgmID = i
 //                                self.showBGMDetailView.toggle()
 								self.navigationPath = [i]
-                            }
-                            break
-                        case "bgmtv":
-                            if let code = queryUrlComponents.queryItems?.first(where: { $0.name == "code" })?.value{
-                                print(code)
-								getBGMTVAccessToken(code: code){ isSuccess, result in
-									if isSuccess{
-										NotificationCenter.default
-											.post(name: Notification.Name("getBGMUserInfo"), object: nil)
-									}else{
-										print("getBGMTVAccessToken failed: \(result)")
-									}
-								}
                             }
                             break
                             default:


### PR DESCRIPTION
Implement Albireo V2 OAuth2 login alongside legacy cookie-based authentication. Adds:
- AlbireoV2ServerHandler for OAuth2 token and API requests
- AlbireoV2Model with data structures for OAuth2 responses
- AuthMode enum to support both legacy and V2 authentication
- Dual authentication path in existing handlers
- Enhanced login UI with method selection (Password/OAuth2)
- Pagination support for Albireo V2 bangumi lists
- Token refresh and expiration handling
- Localization strings for new UI elements
- Maintains backward compatibility with existing cookie-based auth