### PR TITLE
Add video CDN node selection and discovery

### DIFF
--- a/moe.TV.xcodeproj/project.pbxproj
+++ b/moe.TV.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4779043F2F2B91F400EF74D5 /* NowPlayingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4779043E2F2B91D000EF74D5 /* NowPlayingManager.swift */; };
 		47AA00022F30000000123456 /* AlbireoV2ServerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AA00012F30000000123456 /* AlbireoV2ServerHandler.swift */; };
 		47AA00122F30010000123456 /* AlbireoV2Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AA00112F30010000123456 /* AlbireoV2Model.swift */; };
+		47AA00222F30020000123456 /* VideoCDNHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AA00212F30020000123456 /* VideoCDNHandler.swift */; };
 		47CC30782A371784001D3F8C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC30772A371784001D3F8C /* LoginViewController.swift */; };
 		47CC307B2A38952A001D3F8C /* BangumiCellUnreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC307A2A38952A001D3F8C /* BangumiCellUnreadView.swift */; };
 		47CC307D2A389AE7001D3F8C /* BangumiDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47CC307C2A389AE7001D3F8C /* BangumiDetailModel.swift */; };
@@ -119,6 +120,7 @@
 		4779043E2F2B91D000EF74D5 /* NowPlayingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingManager.swift; sourceTree = "<group>"; };
 		47AA00012F30000000123456 /* AlbireoV2ServerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbireoV2ServerHandler.swift; sourceTree = "<group>"; };
 		47AA00112F30010000123456 /* AlbireoV2Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbireoV2Model.swift; sourceTree = "<group>"; };
+		47AA00212F30020000123456 /* VideoCDNHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCDNHandler.swift; sourceTree = "<group>"; };
 		47CC30772A371784001D3F8C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		47CC307A2A38952A001D3F8C /* BangumiCellUnreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BangumiCellUnreadView.swift; sourceTree = "<group>"; };
 		47CC307C2A389AE7001D3F8C /* BangumiDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BangumiDetailModel.swift; sourceTree = "<group>"; };
@@ -287,6 +289,7 @@
 				866E4EB12CE3AC270077D38D /* PlaybackHistoryHandler.swift */,
 				8627A9312A343D6500A5FCAC /* AlbireoServerHandler.swift */,
 				47AA00012F30000000123456 /* AlbireoV2ServerHandler.swift */,
+				47AA00212F30020000123456 /* VideoCDNHandler.swift */,
 				86112E852A3C73F60034AD97 /* BGMTVServerHandler.swift */,
 				8658C6902A50839100357761 /* OpenURL.swift */,
 				86B06C2F2C156B2400169F55 /* ViewUtils.swift */,
@@ -573,6 +576,7 @@
 				86112E862A3C73F60034AD97 /* BGMTVServerHandler.swift in Sources */,
 				8627A9322A343D6500A5FCAC /* AlbireoServerHandler.swift in Sources */,
 				47AA00022F30000000123456 /* AlbireoV2ServerHandler.swift in Sources */,
+				47AA00222F30020000123456 /* VideoCDNHandler.swift in Sources */,
 				47AA00122F30010000123456 /* AlbireoV2Model.swift in Sources */,
 				8622C61C2A9261B70099DC78 /* ProgressAlertView.swift in Sources */,
 				47CC307D2A389AE7001D3F8C /* BangumiDetailModel.swift in Sources */,

--- a/moe.TV/Controller/BangumiDetailViewController.swift
+++ b/moe.TV/Controller/BangumiDetailViewController.swift
@@ -15,10 +15,13 @@ struct NewEPItem:Decodable {
 
 class BangumiDetailViewController : ObservableObject {
 	private let settingsHandler = SettingsHandler()
+	private var pendingPlaybackAfterNotice: (url: String, seekTime: Double, isOffline: Bool, filename: String?)?
 
-    @Published var presentVideoView = false
-    @Published var presentContinuePlayAlert = false
-    @Published var presentSourceSelectAlert = false
+	    @Published var presentVideoView = false
+	    @Published var presentContinuePlayAlert = false
+	    @Published var presentSourceSelectAlert = false
+		@Published var presentPlaybackNoticeAlert = false
+		@Published var playbackNoticeMessage = ""
     
     @Published var videoURL:String = ""
     @Published var videoIsOffline = false
@@ -90,23 +93,57 @@ class BangumiDetailViewController : ObservableObject {
             }
             
         }else{
-            if let vFile = ep.video_files{
-                if let url0 = vFile[0].url{
-                    let urlstr = fixPathNotCompete(path: url0).addingPercentEncoding(withAllowedCharacters:.urlQueryAllowed)!
-                    self.showVideoView(url: urlstr, seekTime: seekTime)
-                }else{
-                    print("vFile[0].url is empty!")
-                }
+	            if let vFile = ep.video_files{
+	                if let url0 = vFile[0].url{
+						self.prepareAndShowVideoView(url: url0, seekTime: seekTime)
+	                }else{
+	                    print("vFile[0].url is empty!")
+	                }
             }else{
                 print("ep.video_files is empty!")
             }
         }
     }
-    
-    
-    
-    //4 start playback
-    func showVideoView(url:String, seekTime:Double, isOffline: Bool = false, filename: String? = nil) {
+		func prepareAndShowVideoView(url: String, seekTime: Double, isOffline: Bool = false, filename: String? = nil) {
+			let urlstr = fixPathNotCompete(path: url).addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? url
+			guard !isOffline else {
+				showVideoView(url: urlstr, seekTime: seekTime, isOffline: isOffline, filename: filename)
+				return
+			}
+
+			resolveVideoCDNPlaybackURL(urlstr) { resolvedURL, notice in
+				DispatchQueue.main.async {
+					if let notice, !notice.isEmpty {
+						self.playbackNoticeMessage = notice
+						self.pendingPlaybackAfterNotice = (
+							url: resolvedURL,
+							seekTime: seekTime,
+							isOffline: isOffline,
+							filename: filename
+						)
+						self.presentPlaybackNoticeAlert = true
+						return
+					}
+					self.showVideoView(url: resolvedURL, seekTime: seekTime, isOffline: isOffline, filename: filename)
+				}
+			}
+		}
+
+		func continuePendingPlaybackAfterNotice() {
+			guard let pendingPlaybackAfterNotice else {
+				return
+			}
+			self.pendingPlaybackAfterNotice = nil
+			showVideoView(
+				url: pendingPlaybackAfterNotice.url,
+				seekTime: pendingPlaybackAfterNotice.seekTime,
+				isOffline: pendingPlaybackAfterNotice.isOffline,
+				filename: pendingPlaybackAfterNotice.filename
+			)
+		}
+
+	    //4 start playback
+	    func showVideoView(url:String, seekTime:Double, isOffline: Bool = false, filename: String? = nil) {
         DispatchQueue.main.async {
             self.presentVideoView = false
             self.seek = seekTime

--- a/moe.TV/Controller/SettingsViewController.swift
+++ b/moe.TV/Controller/SettingsViewController.swift
@@ -23,15 +23,29 @@ class SettingsViewController: ObservableObject{
 	@Published var settingsHandler = SettingsHandler()
 
 	@Published var playbackRate:Double = 1.0
+	@Published var videoCDNGroup: String = ""
+	@Published var videoCDNOptions: [VideoCDNOption] = []
+	@Published var isRefreshingVideoCDNOptions = false
+	@Published var videoCDNStatusMessage = ""
+	private var isRefreshingVideoCDNLatencies = false
 
 	init() {
 		getBGMLoginStatus()
+		settingsHandler.registerSettings()
+		loadVideoCDNSettings()
 		
 		NotificationCenter.default
 			.addObserver(
 				self,
 				selector: #selector(getBGMUserInfo),
 				name: Notification.Name("getBGMUserInfo"),
+				object: nil
+			)
+		NotificationCenter.default
+			.addObserver(
+				self,
+				selector: #selector(handleVideoCDNSettingsDidChange),
+				name: Notification.Name("videoCDNSettingsDidChange"),
 				object: nil
 			)
 	}
@@ -99,6 +113,84 @@ class SettingsViewController: ObservableObject{
 			self.isBGMSyncEnabled = true
 		}else{
 			self.isBGMSyncEnabled = false
+		}
+	}
+
+	func saveVideoCDNGroup(_ group: String) {
+		settingsHandler.setVideoCDNGroup(group)
+		DispatchQueue.main.async {
+			self.videoCDNGroup = group
+		}
+	}
+
+	func loadVideoCDNSettings() {
+		videoCDNGroup = settingsHandler.getVideoCDNGroup()
+		videoCDNOptions = sortedVideoCDNOptions(settingsHandler.getVideoCDNOptions())
+	}
+
+	@objc private func handleVideoCDNSettingsDidChange() {
+		loadVideoCDNSettings()
+	}
+
+	func refreshVideoCDNOptions() {
+		guard !isRefreshingVideoCDNOptions else { return }
+		isRefreshingVideoCDNOptions = true
+		videoCDNStatusMessage = "Loading video CDN nodes..."
+		refreshVideoCDNOptionsFromFirstPlayableEpisode { isSuccess, data in
+			DispatchQueue.main.async {
+				self.isRefreshingVideoCDNOptions = false
+				if isSuccess, let options = data as? [VideoCDNOption] {
+					self.videoCDNOptions = self.sortedVideoCDNOptions(options)
+					self.videoCDNStatusMessage = "Video CDN nodes updated."
+					if !self.videoCDNGroup.isEmpty,
+					   !options.contains(where: { $0.name == self.videoCDNGroup && $0.isSelectable }) {
+						self.saveVideoCDNGroup("")
+						self.videoCDNStatusMessage = "Selected video CDN is unavailable. Switched to automatic CDN."
+					}
+				} else {
+					self.videoCDNStatusMessage = "\(data)"
+				}
+			}
+		}
+	}
+
+	func refreshVideoCDNLatencies() {
+		guard !isRefreshingVideoCDNLatencies else { return }
+		let currentOptions = videoCDNOptions
+		guard !currentOptions.isEmpty else { return }
+		isRefreshingVideoCDNLatencies = true
+
+		updateVideoCDNOptionLatencies(currentOptions) { options in
+			DispatchQueue.main.async {
+				self.isRefreshingVideoCDNLatencies = false
+				self.videoCDNOptions = self.sortedVideoCDNOptions(options)
+			}
+		}
+	}
+
+	private func sortedVideoCDNOptions(_ options: [VideoCDNOption]) -> [VideoCDNOption] {
+		options.sorted { lhs, rhs in
+			if lhs.isGroup != rhs.isGroup {
+				return lhs.isGroup
+			}
+
+			if lhs.isGroup && rhs.isGroup {
+				return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+			}
+
+			switch (lhs.latencyMS, rhs.latencyMS) {
+			case let (lhsLatency?, rhsLatency?) where lhsLatency != rhsLatency:
+				return lhsLatency < rhsLatency
+			case (_?, nil):
+				return true
+			case (nil, _?):
+				return false
+			default:
+				if lhs.offline != rhs.offline {
+					return !lhs.offline
+				}
+				return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+			}
 		}
 	}
 }

--- a/moe.TV/Shared/SettingsHandler.swift
+++ b/moe.TV/Shared/SettingsHandler.swift
@@ -12,6 +12,67 @@ enum AlbireoAuthMode: String {
 	case albireoV2OAuth
 }
 
+struct VideoCDNOption: Identifiable, Hashable, Codable {
+	let name: String
+	let url: String?
+	let servers: [String]?
+	let offline: Bool
+	let check: Bool?
+	let lastOnline: String?
+	let count: Int?
+	let type: String?
+	var latencyMS: Int?
+
+	var id: String { name }
+	var isGroup: Bool { servers?.isEmpty == false }
+	var isSelectable: Bool { isGroup || !offline }
+
+	enum CodingKeys: String, CodingKey {
+		case name = "Name"
+		case url = "URL"
+		case servers = "Servers"
+		case offline = "Offline"
+		case check = "Check"
+		case lastOnline = "LastOnline"
+		case count = "Count"
+		case type = "Type"
+		case latencyMS
+	}
+
+	init(name: String,
+		 url: String?,
+		 servers: [String]?,
+		 offline: Bool,
+		 check: Bool?,
+		 lastOnline: String?,
+		 count: Int?,
+		 type: String?,
+		 latencyMS: Int? = nil) {
+		self.name = name
+		self.url = url
+		self.servers = servers
+		self.offline = offline
+		self.check = check
+		self.lastOnline = lastOnline
+		self.count = count
+		self.type = type
+		self.latencyMS = latencyMS
+	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		name = try container.decode(String.self, forKey: .name)
+		url = try container.decodeIfPresent(String.self, forKey: .url)
+		servers = try container.decodeIfPresent([String].self, forKey: .servers)
+		offline = try container.decodeIfPresent(Bool.self, forKey: .offline) ?? false
+		check = try container.decodeIfPresent(Bool.self, forKey: .check)
+		lastOnline = try container.decodeIfPresent(String.self, forKey: .lastOnline)
+		count = try container.decodeIfPresent(Int.self, forKey: .count)
+		type = try container.decodeIfPresent(String.self, forKey: .type)
+		latencyMS = try container.decodeIfPresent(Int.self, forKey: .latencyMS)
+	}
+}
+
 class SettingsHandler {
 	// MARK: - Keys
     private let UD_SUITE_NAME = "group.moetv"
@@ -29,6 +90,8 @@ class SettingsHandler {
 	private let kAlbireoV2APIServerURL = "kAlbireoV2APIServerURL"
 	private let kAlbireoV2ClientID = "kAlbireoV2ClientID"
 	private let kAlbireoV2RedirectHost = "kAlbireoV2RedirectHost"
+	private let kVideoCDNGroup = "kVideoCDNGroup"
+	private let kVideoCDNOptions = "kVideoCDNOptions"
 
 	private let kLandscapePlayback = "kLandscapePlayback"
 	private let kShowBgmtvWebWhilePlaying = "kShowBgmtvWebWhilePlaying"
@@ -159,6 +222,30 @@ class SettingsHandler {
 	}
 	func getAlbireoV2RedirectHost() -> String {
 		return ub.string(forKey: kAlbireoV2RedirectHost) ?? ""
+	}
+	func setVideoCDNGroup(_ group: String) {
+		ub.set(group, forKey: kVideoCDNGroup)
+		sync()
+	}
+	func getVideoCDNGroup() -> String {
+		if let group = ub.string(forKey: kVideoCDNGroup), !group.isEmpty {
+			return group
+		}
+		return ub.string(forKey: "kAlbireoV2VideoCDNGroup") ?? ""
+	}
+	func setVideoCDNOptions(_ options: [VideoCDNOption]) {
+		if let data = try? JSONEncoder().encode(options) {
+			ub.set(data, forKey: kVideoCDNOptions)
+			sync()
+		}
+	}
+	func getVideoCDNOptions() -> [VideoCDNOption] {
+		let storedData = ub.data(forKey: kVideoCDNOptions) ?? ub.data(forKey: "kAlbireoV2VideoCDNOptions")
+		guard let data = storedData,
+			  let options = try? JSONDecoder().decode([VideoCDNOption].self, from: data) else {
+			return []
+		}
+		return options
 	}
 
 	//BGMTV Username

--- a/moe.TV/Shared/StreamingAVPlayerCache.swift
+++ b/moe.TV/Shared/StreamingAVPlayerCache.swift
@@ -121,6 +121,9 @@ final class StreamingCacheManager: ObservableObject {
 		var request = URLRequest(url: originalURL)
 		request.setValue("bytes=0-1", forHTTPHeaderField: "Range")
 		request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+		for (field, value) in videoCDNHTTPHeaderFields(for: originalURL) {
+			request.setValue(value, forHTTPHeaderField: field)
+		}
 
 		let (_, response) = try await session.data(for: request)
 		guard let http = response as? HTTPURLResponse else {
@@ -395,6 +398,9 @@ final class StreamingCacheManager: ObservableObject {
 		var request = URLRequest(url: originalURL)
 		request.setValue("bytes=\(range.start)-\(range.end)", forHTTPHeaderField: "Range")
 		request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+		for (field, value) in videoCDNHTTPHeaderFields(for: originalURL) {
+			request.setValue(value, forHTTPHeaderField: field)
+		}
 
 		let (data, response) = try await session.data(for: request)
 

--- a/moe.TV/Shared/VideoCDNHandler.swift
+++ b/moe.TV/Shared/VideoCDNHandler.swift
@@ -1,0 +1,315 @@
+//
+//  VideoCDNHandler.swift
+//  moe.TV
+//
+//  Handles video CDN node discovery and playback URL selection.
+//
+
+import Foundation
+
+private let videoCDNSettingsHandler = SettingsHandler()
+private let videoCDNSettingsDidChangeNotification = Notification.Name("videoCDNSettingsDidChange")
+
+func getVideoCDNOptions(videoURLString: String,
+						includeLatency: Bool = false,
+						completion: @escaping (Bool, Any) -> Void) {
+	guard let url = URL(string: videoURLString) else {
+		completion(false, "Invalid video URL: \(videoURLString)")
+		return
+	}
+
+	postVideoCDNRequest(url: url, groupName: nil) { result in
+		switch result {
+		case .success(let response):
+			guard let data = response.data else {
+				completion(false, "Video CDN response is empty.")
+				return
+			}
+			do {
+				let options = try JSONDecoder().decode([VideoCDNOption].self, from: data)
+				if includeLatency {
+					measureVideoCDNLatency(options: options) { measuredOptions in
+						videoCDNSettingsHandler.setVideoCDNOptions(measuredOptions)
+						completion(true, measuredOptions)
+					}
+				} else {
+					videoCDNSettingsHandler.setVideoCDNOptions(options)
+					completion(true, options)
+				}
+			} catch {
+				let responseText = String(data: data, encoding: .utf8) ?? ""
+				completion(false, "Video CDN decode failed: \(error.localizedDescription), response: \(responseText)")
+			}
+		case .failure(let message):
+			completion(false, message)
+		}
+	}
+}
+
+func updateVideoCDNOptionLatencies(_ options: [VideoCDNOption],
+								   completion: @escaping ([VideoCDNOption]) -> Void) {
+	measureVideoCDNLatency(options: options, completion: completion)
+}
+
+func refreshVideoCDNOptionsFromFirstPlayableEpisode(completion: @escaping (Bool, Any) -> Void) {
+	videoCDNSettingsHandler.registerSettings()
+	switch videoCDNSettingsHandler.getAlbireoAuthMode() {
+	case .albireoV2OAuth:
+		refreshVideoCDNOptionsFromAlbireoV2Sample(completion: completion)
+	case .legacyCookie:
+		refreshVideoCDNOptionsFromLegacyAlbireoSample(completion: completion)
+	}
+}
+
+func resolveVideoCDNPlaybackURL(_ videoURLString: String,
+								completion: @escaping (String, String?) -> Void) {
+	videoCDNSettingsHandler.registerSettings()
+	let selectedGroup = videoCDNSettingsHandler.getVideoCDNGroup().trimmingCharacters(in: .whitespacesAndNewlines)
+	guard !selectedGroup.isEmpty else {
+		clearVideoCDNPlaybackCookie(for: URL(string: videoURLString))
+		completion(videoURLString, nil)
+		return
+	}
+
+	getVideoCDNOptions(videoURLString: videoURLString) { isSuccess, data in
+		if isSuccess, let options = data as? [VideoCDNOption] {
+			guard let selectedOption = options.first(where: { $0.name == selectedGroup }),
+				  selectedOption.isSelectable else {
+				switchVideoCDNToAutomatic(for: URL(string: videoURLString))
+				completion(videoURLString, "Selected video CDN is unavailable. Switched to automatic CDN.")
+				return
+			}
+		} else {
+			print("Video CDN list refresh failed before playback: \(data)")
+		}
+
+		guard let url = URL(string: videoURLString) else {
+			completion(videoURLString, "Invalid video URL. Switched to original URL.")
+			return
+		}
+
+		postVideoCDNRequest(url: url, groupName: selectedGroup) { result in
+			switch result {
+			case .success:
+				applyVideoCDNPlaybackCookie(groupName: selectedGroup, for: url)
+				completion(videoURLString, nil)
+			case .failure(let message):
+				switchVideoCDNToAutomatic(for: url)
+				completion(videoURLString, "\(message) Switched to automatic CDN.")
+			}
+		}
+	}
+}
+
+private func switchVideoCDNToAutomatic(for url: URL?) {
+	videoCDNSettingsHandler.setVideoCDNGroup("")
+	clearVideoCDNPlaybackCookie(for: url)
+	DispatchQueue.main.async {
+		NotificationCenter.default.post(name: videoCDNSettingsDidChangeNotification, object: nil)
+	}
+}
+
+func videoCDNHTTPHeaderFields(for url: URL) -> [String: String] {
+	videoCDNSettingsHandler.registerSettings()
+	let selectedGroup = videoCDNSettingsHandler.getVideoCDNGroup().trimmingCharacters(in: .whitespacesAndNewlines)
+	guard !selectedGroup.isEmpty else {
+		return [:]
+	}
+	return ["Cookie": "group=\(selectedGroup)"]
+}
+
+private func applyVideoCDNPlaybackCookie(groupName: String, for url: URL) {
+	guard let host = url.host, !groupName.isEmpty else { return }
+	clearVideoCDNPlaybackCookie(for: url)
+
+	let properties: [HTTPCookiePropertyKey: Any] = [
+		.domain: host,
+		.path: "/",
+		.name: "group",
+		.value: groupName,
+		.secure: url.scheme == "https",
+		.expires: Date(timeIntervalSinceNow: 60 * 60)
+	]
+
+	if let cookie = HTTPCookie(properties: properties) {
+		HTTPCookieStorage.shared.setCookie(cookie)
+	}
+}
+
+private func clearVideoCDNPlaybackCookie(for url: URL?) {
+	guard let url, let host = url.host else { return }
+	HTTPCookieStorage.shared.cookies?
+		.filter { $0.name == "group" && $0.domain == host }
+		.forEach { HTTPCookieStorage.shared.deleteCookie($0) }
+}
+
+private func refreshVideoCDNOptionsFromAlbireoV2Sample(completion: @escaping (Bool, Any) -> Void) {
+	getAlbireoV2OnAirList { isSuccess, data in
+		guard isSuccess, let responseData = data as? Data else {
+			completion(false, "Failed to load Albireo V2 on-air list for CDN refresh: \(data)")
+			return
+		}
+		do {
+			let bangumiList = try decodeAlbireoV2BangumiItems(from: responseData)
+			guard let bangumi = bangumiList.first else {
+				completion(false, "Albireo V2 on-air list is empty.")
+				return
+			}
+			getAlbireoV2BangumiDetail(id: bangumi.id) { isDetailSuccess, detailData in
+				guard isDetailSuccess, let detailResponseData = detailData as? Data else {
+					completion(false, "Failed to load Albireo V2 bangumi detail for CDN refresh: \(detailData)")
+					return
+				}
+				do {
+					let detail = try decodeAlbireoV2BangumiDetail(from: detailResponseData)
+					guard let episode = detail.episodes?.first else {
+						completion(false, "Albireo V2 bangumi detail has no episodes for CDN refresh.")
+						return
+					}
+					getAlbireoV2EpisodeDetail(epID: episode.id, defaultBangumiID: detail.id) { isEpisodeSuccess, episodeData in
+						guard isEpisodeSuccess, let episodeDetail = episodeData as? EpisodeDetailModel else {
+							completion(false, "Failed to load Albireo V2 episode detail for CDN refresh: \(episodeData)")
+							return
+						}
+						guard let videoURL = episodeDetail.video_files?.first?.url, !videoURL.isEmpty else {
+							completion(false, "Albireo V2 episode detail has no video URL for CDN refresh.")
+							return
+						}
+						getVideoCDNOptions(videoURLString: fixPathNotCompete(path: videoURL), includeLatency: true, completion: completion)
+					}
+				} catch {
+					completion(false, "Albireo V2 bangumi detail decode failed for CDN refresh: \(error.localizedDescription)")
+				}
+			}
+		} catch {
+			completion(false, "Albireo V2 on-air list decode failed for CDN refresh: \(error.localizedDescription)")
+		}
+	}
+}
+
+private func refreshVideoCDNOptionsFromLegacyAlbireoSample(completion: @escaping (Bool, Any) -> Void) {
+	getAlbireoOnAirList { isSuccess, data in
+		guard isSuccess, let bangumiList = data as? [BangumiItemModel], let bangumi = bangumiList.first else {
+			completion(false, "Failed to load Albireo on-air list for CDN refresh: \(String(describing: data))")
+			return
+		}
+		getAlbireoBangumiDetail(id: bangumi.id) { isDetailSuccess, detailData in
+			guard isDetailSuccess, let detail = detailData as? BangumiDetailModel, let episode = detail.episodes?.first else {
+				completion(false, "Failed to load Albireo bangumi detail for CDN refresh: \(String(describing: detailData))")
+				return
+			}
+			getAlbireoEPDetail(ep_id: episode.id) { isEpisodeSuccess, episodeData in
+				guard isEpisodeSuccess, let episodeDetail = episodeData as? EpisodeDetailModel else {
+					completion(false, "Failed to load Albireo episode detail for CDN refresh: \(String(describing: episodeData))")
+					return
+				}
+				guard let videoURL = episodeDetail.video_files?.first?.url, !videoURL.isEmpty else {
+					completion(false, "Albireo episode detail has no video URL for CDN refresh.")
+					return
+				}
+				getVideoCDNOptions(videoURLString: fixPathNotCompete(path: videoURL), includeLatency: true, completion: completion)
+			}
+		}
+	}
+}
+
+private struct VideoCDNPOSTResponse {
+	let data: Data?
+	let redirectURL: URL?
+}
+
+private enum VideoCDNPOSTResult {
+	case success(VideoCDNPOSTResponse)
+	case failure(String)
+}
+
+private final class VideoCDNRedirectBlocker: NSObject, URLSessionTaskDelegate {
+	private let onRedirect: (URL) -> Void
+
+	init(onRedirect: @escaping (URL) -> Void) {
+		self.onRedirect = onRedirect
+	}
+
+	func urlSession(_ session: URLSession,
+					task: URLSessionTask,
+					willPerformHTTPRedirection response: HTTPURLResponse,
+					newRequest request: URLRequest,
+					completionHandler: @escaping (URLRequest?) -> Void) {
+		if let url = request.url {
+			onRedirect(url)
+		}
+		completionHandler(nil)
+	}
+}
+
+private func postVideoCDNRequest(url: URL,
+								 groupName: String?,
+								 completion: @escaping (VideoCDNPOSTResult) -> Void) {
+	var redirectURL: URL?
+	let delegate = VideoCDNRedirectBlocker { url in
+		redirectURL = url
+	}
+	let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+	var request = URLRequest(url: url)
+	request.httpMethod = "POST"
+	request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+	request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+	if let groupName, !groupName.isEmpty {
+		request.setValue("group=\(groupName)", forHTTPHeaderField: "Cookie")
+	}
+	videoCDNSettingsHandler.registerSettings()
+	let accessToken = videoCDNSettingsHandler.getAlbireoV2AccessToken()
+	if !accessToken.isEmpty {
+		request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+	}
+
+	session.dataTask(with: request) { data, response, error in
+		defer {
+			session.finishTasksAndInvalidate()
+		}
+		if let error {
+			completion(.failure(error.localizedDescription))
+			return
+		}
+		if let redirectURL {
+			completion(.success(VideoCDNPOSTResponse(data: data, redirectURL: redirectURL)))
+			return
+		}
+		if let httpResponse = response as? HTTPURLResponse,
+		   httpResponse.statusCode < 200 || httpResponse.statusCode >= 300 {
+			let responseText = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+			completion(.failure("Video CDN POST HTTP \(httpResponse.statusCode): \(responseText)"))
+			return
+		}
+		completion(.success(VideoCDNPOSTResponse(data: data, redirectURL: nil)))
+	}.resume()
+}
+
+private func measureVideoCDNLatency(options: [VideoCDNOption],
+									completion: @escaping ([VideoCDNOption]) -> Void) {
+	var measuredOptions = options
+	let group = DispatchGroup()
+	let lock = NSLock()
+
+	for (index, option) in options.enumerated() {
+		guard option.isSelectable, let urlString = option.url, let url = URL(string: urlString) else {
+			continue
+		}
+		group.enter()
+		let start = Date()
+		var request = URLRequest(url: url)
+		request.httpMethod = "HEAD"
+		request.timeoutInterval = 4
+		URLSession.shared.dataTask(with: request) { _, _, _ in
+			let latency = max(1, Int(Date().timeIntervalSince(start) * 1000))
+			lock.lock()
+			measuredOptions[index].latencyMS = latency
+			lock.unlock()
+			group.leave()
+		}.resume()
+	}
+
+	group.notify(queue: .global()) {
+		completion(measuredOptions)
+	}
+}

--- a/moe.TV/Support Files/Localizable.xcstrings
+++ b/moe.TV/Support Files/Localizable.xcstrings
@@ -38,6 +38,9 @@
     "%lld" : {
       "shouldTranslate" : false
     },
+    "%lld ms" : {
+      "shouldTranslate" : false
+    },
     "%lld. " : {
       "shouldTranslate" : false
     },
@@ -444,6 +447,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "授權伺服器地址"
+          }
+        }
+      }
+    },
+    "Automatic" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動"
           }
         }
       }
@@ -1378,6 +1403,52 @@
         }
       }
     },
+    "Group" : {
+      "comment" : "Video CDN group label",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "グループ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分组"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "群組"
+          }
+        }
+      }
+    },
+    "Group: %@" : {
+      "comment" : "Video CDN group server list",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "グループ: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分组：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "群組：%@"
+          }
+        }
+      }
+    },
     "Hide unrelease/empty EPs" : {
       "localizations" : {
         "ja" : {
@@ -1450,6 +1521,28 @@
     "ID: %@" : {
       "shouldTranslate" : false
     },
+    "Invalid video URL. Switched to original URL." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画URLが無効です。元のURLに切り替えました。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频 URL 无效，已切换为原始 URL。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "影片 URL 無效，已切換為原始 URL。"
+          }
+        }
+      }
+    },
     "Later" : {
       "localizations" : {
         "ja" : {
@@ -1468,6 +1561,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "稍後"
+          }
+        }
+      }
+    },
+    "Loading video CDN nodes..." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画CDNノードを読み込み中..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载视频 CDN 节点..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在載入影片 CDN 節點..."
           }
         }
       }
@@ -1812,6 +1927,29 @@
         }
       }
     },
+    "Offline" : {
+      "comment" : "Video CDN offline status",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線"
+          }
+        }
+      }
+    },
     "OK" : {
       "shouldTranslate" : false
     },
@@ -1834,6 +1972,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "推薦"
+          }
+        }
+      }
+    },
+    "Online" : {
+      "comment" : "Video CDN online status",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンライン"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在线"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "線上"
           }
         }
       }
@@ -2014,6 +2175,28 @@
         }
       }
     },
+    "Playback notice" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再生のお知らせ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放提示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放提示"
+          }
+        }
+      }
+    },
     "Playback speed" : {
       "localizations" : {
         "ja" : {
@@ -2190,6 +2373,28 @@
         }
       }
     },
+    "Refresh video CDN nodes" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画CDNノードを更新"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新视频 CDN 节点"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理影片 CDN 節點"
+          }
+        }
+      }
+    },
     "RefreshToken" : {
       "localizations" : {
         "ja" : {
@@ -2297,6 +2502,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇"
+          }
+        }
+      }
+    },
+    "Selected video CDN is unavailable. Switched to automatic CDN." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択した動画CDNは利用できません。自動CDNに切り替えました。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择的视频 CDN 不可用，已切换为自动 CDN。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選擇的影片 CDN 無法使用，已切換為自動 CDN。"
           }
         }
       }
@@ -2723,6 +2950,28 @@
         }
       }
     },
+    "Use password login on tvOS. For OAuth2 login, please log in on another device and enable iCloud sync." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tvOS ではパスワードログインを使用できます。OAuth2 ログインは別のデバイスで行い、iCloud 同期を有効にしてください。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tvOS 可使用密码登录。OAuth2 登录请在其他设备完成，并开启 iCloud 同步。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tvOS 可使用密碼登入。OAuth2 登入請在其他裝置完成，並開啟 iCloud 同步。"
+          }
+        }
+      }
+    },
     "Username" : {
       "localizations" : {
         "ja" : {
@@ -2767,28 +3016,6 @@
         }
       }
     },
-    "Use password login on tvOS. For OAuth2 login, please log in on another device and enable iCloud sync." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tvOS ではパスワードログインを使用できます。OAuth2 ログインは別のデバイスで行い、iCloud 同期を有効にしてください。"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tvOS 可使用密码登录。OAuth2 登录请在其他设备完成，并开启 iCloud 同步。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tvOS 可使用密碼登入。OAuth2 登入請在其他裝置完成，並開啟 iCloud 同步。"
-          }
-        }
-      }
-    },
     "Version:%@, Build:%@" : {
       "localizations" : {
         "en" : {
@@ -2799,6 +3026,72 @@
         }
       },
       "shouldTranslate" : false
+    },
+    "Video CDN" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画CDN"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频 CDN"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "影片 CDN"
+          }
+        }
+      }
+    },
+    "Video CDN Nodes" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画CDNノード"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频 CDN 节点"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "影片 CDN 節點"
+          }
+        }
+      }
+    },
+    "Video CDN nodes updated." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動画CDNノードを更新しました。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频 CDN 节点已更新。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "影片 CDN 節點已更新。"
+          }
+        }
+      }
     },
     "Volume %@" : {
       "localizations" : {

--- a/moe.TV/Views/BGMDetail/BangumiDetailView.swift
+++ b/moe.TV/Views/BGMDetail/BangumiDetailView.swift
@@ -207,7 +207,7 @@ struct BangumiDetailView: View {
 							?? [], id: \.self){ item in
 						Button(item.file_name ?? "\(item.url ?? "unknown source")"){
 							if let urlstr = item.url{
-								detailVC.showVideoView(url: fixPathNotCompete(path: urlstr).addingPercentEncoding(withAllowedCharacters:.urlQueryAllowed)!, seekTime: detailVC.seek)
+								detailVC.prepareAndShowVideoView(url: urlstr, seekTime: detailVC.seek)
 							}else{
 								print("item.url is empty!")
 							}
@@ -224,6 +224,13 @@ struct BangumiDetailView: View {
 					detailVC.checkVideoSource(ep: detailVC.ep!, seekTime: 0)
 				}
 
+			}
+			.alert("Playback notice", isPresented: $detailVC.presentPlaybackNoticeAlert) {
+				Button("OK", role: .cancel) {
+					detailVC.continuePendingPlaybackAfterNotice()
+				}
+			} message: {
+				Text(detailVC.playbackNoticeMessage)
 			}
             
 

--- a/moe.TV/Views/SettingsView.swift
+++ b/moe.TV/Views/SettingsView.swift
@@ -213,6 +213,19 @@ struct SettingsView: View {
 							//TODO: hide not-onair items switch
 					}
 
+					Section(header: Text("Video CDN")) {
+						NavigationLink {
+							VideoCDNSettingsView(settingsVC: settingsVC)
+						} label: {
+							HStack {
+								Text("Video CDN")
+								Spacer()
+								Text(settingsVC.videoCDNGroup.isEmpty ? "Automatic" : settingsVC.videoCDNGroup)
+									.foregroundStyle(.secondary)
+							}
+						}
+					}
+
 					Section(header: Text("Download")) {
 						Button {
 							self.showDownloadList.toggle()
@@ -293,7 +306,165 @@ struct SettingsView: View {
 	}
 
     
-    
+}
+
+struct VideoCDNSettingsView: View {
+	@ObservedObject var settingsVC: SettingsViewController
+
+	var body: some View {
+		List {
+			Section {
+				Button {
+					settingsVC.saveVideoCDNGroup("")
+				} label: {
+					VideoCDNRow(
+						name: "Automatic",
+						statusColor: .green,
+						detail: nil,
+						latencyMS: nil,
+						isSelected: settingsVC.videoCDNGroup.isEmpty,
+						isEnabled: true
+					)
+				}
+				.buttonStyle(.plain)
+			}
+
+			Section(header: Text("Video CDN Nodes")) {
+				if settingsVC.isRefreshingVideoCDNOptions && settingsVC.videoCDNOptions.isEmpty {
+					HStack {
+						ProgressView()
+						Text("Loading video CDN nodes...")
+					}
+				}
+
+				ForEach(settingsVC.videoCDNOptions) { option in
+					Button {
+						if option.isSelectable {
+							settingsVC.saveVideoCDNGroup(option.name)
+						}
+					} label: {
+						VideoCDNRow(
+							name: option.name,
+							statusColor: optionStatusColor(option),
+							detail: optionDetail(option),
+							latencyMS: option.latencyMS,
+							isSelected: settingsVC.videoCDNGroup == option.name,
+							isEnabled: option.isSelectable
+						)
+					}
+					.buttonStyle(.plain)
+					.disabled(!option.isSelectable)
+				}
+			}
+
+			if !settingsVC.videoCDNStatusMessage.isEmpty {
+				Section {
+					Text(settingsVC.videoCDNStatusMessage)
+						.font(.footnote)
+						.foregroundStyle(.secondary)
+				}
+			}
+		}
+		.navigationTitle("Video CDN")
+		.toolbar {
+			ToolbarItem(placement: .automatic) {
+				Button {
+					settingsVC.refreshVideoCDNOptions()
+				} label: {
+					if settingsVC.isRefreshingVideoCDNOptions {
+						ProgressView()
+					} else {
+						Label("Refresh video CDN nodes", systemImage: "arrow.clockwise")
+					}
+				}
+				.disabled(settingsVC.isRefreshingVideoCDNOptions)
+			}
+		}
+		.onAppear {
+			settingsVC.loadVideoCDNSettings()
+			settingsVC.refreshVideoCDNOptions()
+		}
+		.task {
+			while !Task.isCancelled {
+				try? await Task.sleep(nanoseconds: 5_000_000_000)
+				if Task.isCancelled {
+					break
+				}
+				settingsVC.refreshVideoCDNLatencies()
+			}
+		}
+	}
+
+	private func optionStatusColor(_ option: VideoCDNOption) -> Color {
+		if option.isGroup {
+			return .green
+		}
+		return option.offline ? .red : .green
+	}
+
+	private func optionDetail(_ option: VideoCDNOption) -> String {
+		if option.isGroup {
+			let groupLabel = NSLocalizedString("Group", comment: "Video CDN group label")
+			if let servers = option.servers, !servers.isEmpty {
+				return String(format: NSLocalizedString("Group: %@", comment: "Video CDN group server list"), servers.joined(separator: ", "))
+			}
+			return groupLabel
+		}
+		return option.offline
+			? NSLocalizedString("Offline", comment: "Video CDN offline status")
+			: NSLocalizedString("Online", comment: "Video CDN online status")
+	}
+}
+
+private struct VideoCDNRow: View {
+	let name: String
+	let statusColor: Color
+	let detail: String?
+	let latencyMS: Int?
+	let isSelected: Bool
+	let isEnabled: Bool
+
+	var body: some View {
+		HStack(spacing: 12) {
+			Circle()
+				.fill(statusColor)
+				.frame(width: 10, height: 10)
+
+			VStack(alignment: .leading, spacing: 4) {
+				Text(name)
+					.foregroundStyle(isEnabled ? .primary : .secondary)
+				if let detail {
+					Text(detail)
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+			}
+
+			Spacer()
+
+			if let latencyMS {
+				Text("\(latencyMS) ms")
+					.font(.subheadline.monospacedDigit())
+					.foregroundStyle(latencyColor(latencyMS))
+			}
+
+			if isSelected {
+				Image(systemName: "checkmark")
+					.foregroundColor(.accentColor)
+			}
+		}
+		.contentShape(Rectangle())
+	}
+
+	private func latencyColor(_ latencyMS: Int) -> Color {
+		if latencyMS > 1000 {
+			return .red
+		}
+		if latencyMS > 500 {
+			return .yellow
+		}
+		return .green
+	}
 }
 
 //struct SettingsView_Previews: PreviewProvider {


### PR DESCRIPTION
Implement video CDN node selection feature with the following changes:

- New VideoCDNHandler.swift handles node discovery, latency measurement, and URL resolution
- VideoCDNOption struct stores CDN node information with latency tracking
- SettingsHandler extended with methods to persist CDN group and options
- BangumiDetailViewController updated to resolve URLs through CDN handler before playback
- New VideoCDNSettingsView provides UI for browsing and selecting CDN nodes
- Supports both Albireo V2 OAuth and legacy authentication
- Added comprehensive localizations for CDN UI strings
- StreamingCacheManager updated to include CDN HTTP headers in requests