### PR TITLE
Preserve episode finished status when updating progress

### DIFF
--- a/moe.TV.xcodeproj/project.pbxproj
+++ b/moe.TV.xcodeproj/project.pbxproj
@@ -1025,8 +1025,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SDWebImage/SDWebImageSwiftUI";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.3;
+				branch = master;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/moe.TV/Controller/BangumiDetailViewController.swift
+++ b/moe.TV/Controller/BangumiDetailViewController.swift
@@ -361,7 +361,8 @@ class BangumiDetailViewController : ObservableObject {
 		)
 		progress.last_watch_position = snapshot.position
 		progress.percentage = Float(snapshot.percentage)
-		progress.watch_status = snapshot.isFinished ? 2 : 3
+		let wasAlreadyFinished = progress.watch_status == 2
+		progress.watch_status = wasAlreadyFinished || snapshot.isFinished ? 2 : 3
 		item.ep.watch_progress = progress
 		if snapshot.isFinished, let bgmEP = item.bgmEP {
 			item.bgmEP = BGMTVUserEpisodeCollectionModel(

--- a/moe.TV/Controller/PlayerViewController.swift
+++ b/moe.TV/Controller/PlayerViewController.swift
@@ -322,7 +322,11 @@ class PlayerViewController: ObservableObject {
 			percent = 0
 		}
 
-		let isFinished = percent > 0.95
+		let wasAlreadyFinished = ep?.watch_progress?.watch_status == 2
+		let isFinished = wasAlreadyFinished || percent >= 0.95
+		if wasAlreadyFinished, percent < 0.95 {
+			print("Preserve watched episode status while updating replay progress: \(ep?.id ?? "unknown")")
+		}
 		let snapshot = PlaybackProgressSnapshot(
 			position: currentTime,
 			percentage: percent,

--- a/moe.TV/Shared/OfflinePlaybackManager.swift
+++ b/moe.TV/Shared/OfflinePlaybackManager.swift
@@ -62,7 +62,7 @@ class OfflinePlaybackManager: ObservableObject {
                     bgm_eps_id: item.bgm_eps_id ?? oldItem.bgm_eps_id,
                     filename: item.filename,
                     position: item.position,
-                    isFinished: item.isFinished,
+                    isFinished: oldItem.isFinished || item.isFinished,
                     bangumiName: item.bangumiName ?? oldItem.bangumiName,
                     episodeNo: item.episodeNo ?? oldItem.episodeNo,
                     episodeName: item.episodeName ?? oldItem.episodeName


### PR DESCRIPTION
Prevent clearing a previously finished watch status when updating playback progress. BangumiDetailViewController and PlayerViewController now preserve a finished state (checks prior watch_status/isFinished) and use >=0.95 for finished threshold; PlayerViewController logs when preserving status. OfflinePlaybackManager merges isFinished with oldItem.isFinished || item.isFinished to avoid regressions. Also updates SDWebImageSwiftUI package reference in the Xcode project to use the master branch.